### PR TITLE
Cleaned up names

### DIFF
--- a/doi-utils.org
+++ b/doi-utils.org
@@ -462,34 +462,30 @@ Now we define a function that fills in that template from the metadata.
 As different bibtex types share common keys, it is advantageous to separate data extraction from json, and the formatting of the bibtex entry.
 
 #+BEGIN_SRC emacs-lisp :tangle doi-utils.el
-(defmacro defpar (name &optional value)
-  `(progn (defvar ,name)
-          (setf ,name ,value)))
-
-(defpar doi-utils-json-metadata-extract
-    '((type       (plist-get results :type))
-      (author     (mapconcat (lambda (x) (concat (plist-get x :given) " " (plist-get x :family)))
-                   (plist-get results :author) " and "))
-      (title      (plist-get results :title))
-      (subtitle   (plist-get results :subtitle))
-      (journal    (plist-get results :container-title))
-      (series     (plist-get results :container-title))
-      (publisher  (plist-get results :publisher))
-      (volume     (plist-get results :volume))
-      (issue      (plist-get results :issue))
-      (number     (plist-get results :issue))
-      (year       (elt (elt (plist-get (plist-get results :issued) :date-parts) 0) 0))
-      (month      (elt (elt (plist-get (plist-get results :issued) :date-parts) 0) 1))
-      (pages      (plist-get results :page))
-      (doi        (plist-get results :DOI))
-      (url        (plist-get results :URL))
-      (booktitle  (plist-get results :container-title))))
+(setq doi-utils-json-metadata-extract
+      '((type       (plist-get results :type))
+        (author     (mapconcat (lambda (x) (concat (plist-get x :given) " " (plist-get x :family)))
+                     (plist-get results :author) " and "))
+        (title      (plist-get results :title))
+        (subtitle   (plist-get results :subtitle))
+        (journal    (plist-get results :container-title))
+        (series     (plist-get results :container-title))
+        (publisher  (plist-get results :publisher))
+        (volume     (plist-get results :volume))
+        (issue      (plist-get results :issue))
+        (number     (plist-get results :issue))
+        (year       (elt (elt (plist-get (plist-get results :issued) :date-parts) 0) 0))
+        (month      (elt (elt (plist-get (plist-get results :issued) :date-parts) 0) 1))
+        (pages      (plist-get results :page))
+        (doi        (plist-get results :DOI))
+        (url        (plist-get results :URL))
+        (booktitle  (plist-get results :container-title))))
 #+END_SRC
 
 Next, we need to define the different bibtex types. Each type has a bibtex type (for output) and the type as provided in the doi record. Finally, we have to declare the fields we want to output.
 
 #+BEGIN_SRC emacs-lisp :tangle doi-utils.el :results none
-(defpar doi-utils-bibtex-type-generators nil)
+(setq doi-utils-bibtex-type-generators nil)
 
 (defun concat-prepare (lst &optional acc)
   "Given a list `lst' of strings and other expressions, which are

--- a/doi-utils.org
+++ b/doi-utils.org
@@ -487,7 +487,7 @@ Next, we need to define the different bibtex types. Each type has a bibtex type 
 #+BEGIN_SRC emacs-lisp :tangle doi-utils.el :results none
 (setq doi-utils-bibtex-type-generators nil)
 
-(defun concat-prepare (lst &optional acc)
+(defun doi-utils-concat-prepare (lst &optional acc)
   "Given a list `lst' of strings and other expressions, which are
 intented to passed to `concat', concat any subsequent strings,
 minimising the number of arguments being passed to `concat'
@@ -495,10 +495,9 @@ without changing the results."
   (cond ((null lst) (nreverse acc))
         ((and (stringp (car lst))
               (stringp (car acc)))
-         (concat-prepare (cdr lst) (cons (concat (car acc) (car lst))
+         (doi-utils-concat-prepare (cdr lst) (cons (concat (car acc) (car lst))
                                          (cdr acc))))
-        (t (concat-prepare (cdr lst) (cons (car lst) acc)))))
-
+        (t (doi-utils-concat-prepare (cdr lst) (cons (car lst) acc)))))
 
 (defmacro doi-utils-def-bibtex-type (name matching-types &rest fields)
   "Define a BibTeX type identified by (symbol) `name' with
@@ -516,7 +515,7 @@ when the `:type' parameter in the JSON metadata is contained in
                                    (error "unknown bibtex field type %s" field))))
                            fields)
                (concat
-                ,@(concat-prepare
+                ,@(doi-utils-concat-prepare
                    (-flatten
                     (list (concat "@" (symbol-name name) "{,\n")
                           ;; there seems to be some bug with mapcan,


### PR DESCRIPTION
I got rid of `defpar', in elisp one can simply use `setq'. And renamed `concat-prepare' to respect namespace.