### PR TITLE
Set org-edit-src-content-indentation in org files.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,3 +1,4 @@
+# -*- org-edit-src-content-indentation: 0; -*-
 #+TITLE: org-ref: citations, cross-references, indexes, glossaries and bibtex utilities for org-mode
 
 #+BEGIN_HTML

--- a/doi-utils.org
+++ b/doi-utils.org
@@ -1,3 +1,4 @@
+# -*- org-edit-src-content-indentation: 0; -*-
 #+TITLE: DOI utilities for making bibtex entries and downloading pdfs
 
 This package provides functionality to download PDFs and bibtex entries from a DOI, as well as to update a bibtex entry from a DOI. It depends slightly on org-ref, to determine where to save pdf files too, and where to insert bibtex entries in the default bibliography.

--- a/org-ref.org
+++ b/org-ref.org
@@ -1,3 +1,4 @@
+# -*- org-edit-src-content-indentation: 0; -*-
 #+TITLE: Org-ref - The best reference handling for org-mode
 #+AUTHOR: John Kitchin
 #+DATE: April 29, 2014


### PR DESCRIPTION
John has no indentation in his `#+BEGIN_SRC` blocks, but by default `org-edit-src-code` (bound to `C-c '`) adds two spaces of indentation (see the documentation of `org-edit-src-content-indentation`). This has led to me messing up the whitespace when I edit the org files sometimes. Messing up the whitespace is bad because it makes the Git history hard to read. I've therefore set the file local variable `org-edit-src-content-indentation` to 0 in each `org` file to make sure future users of `org-edit-src-code` won't do this.