### PR TITLE
Use read-string instead of read-input

### DIFF
--- a/arxiv.el
+++ b/arxiv.el
@@ -79,7 +79,7 @@
 (defun arxiv-add-bibtex-entry (arxiv-number bibfile)
   "Add bibtex entry for ARXIV-NUMBER to BIBFILE."
  (interactive
-   (list (read-input "arxiv: ")
+   (list (read-string "arxiv: ")
 	 ;;  now get the bibfile to add it to
 	 (ido-completing-read
 	  "Bibfile: "

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -530,7 +530,7 @@ prompt. If no region is selected and the first entry of the
 kill-ring starts like a DOI, then that is the intial
 prompt. Otherwise, you have to type or pste in a DOI."
   (interactive
-   (list (read-input "DOI: "
+   (list (read-string "DOI: "
 		     ;; now set initial input
 		     (cond
 		      ;; If region is active and it starts like a doi we want it.
@@ -917,7 +917,7 @@ error."
 (defun doi-utils-add-entry-from-crossref-query (query bibtex-file)
   "Search Crossref with QUERY and use helm to select an entry to add to BIBTEX-FILE."
   (interactive (list
-		(read-input
+		(read-string
 		 "Query: "
 		 ;; now set initial input
 		 (cond

--- a/isbn.el
+++ b/isbn.el
@@ -46,7 +46,7 @@ file."
 entry with the generated key already exists in the file."
   (interactive
    (list
-    (read-input
+    (read-string
      "ISBN: "
      ;; now set initial input
      (cond
@@ -104,7 +104,7 @@ entry with the generated key already exists in the file."
     (goto-char (point-min))
     (when (search-forward new-key nil t)
       (beep)
-      (setq new-key (read-input
+      (setq new-key (read-string
 		     (format  "%s already exists. Enter new key (C-g to cancel): " new-key)
 		     new-key)))
     (goto-char (point-max))

--- a/jmax-bibtex.el
+++ b/jmax-bibtex.el
@@ -534,8 +534,8 @@ _u_: Update field _f_: file funcs
    ("K" (lambda ()
 	  (interactive)
 	  (org-ref-set-bibtex-keywords
-	   (read-input "Keywords: "
-		       (bibtex-autokey-get-field "keywords"))
+	   (read-string "Keywords: "
+			(bibtex-autokey-get-field "keywords"))
 	   t)))
    ("b" org-ref-open-in-browser)
    ("r" (lambda () (interactive)

--- a/org-ref.el
+++ b/org-ref.el
@@ -3063,7 +3063,7 @@ first key that partially matches.  This version avoids that."
 User is prompted for tags.  This function is called from `helm-bibtex'.
 Argument CANDIDATES helm candidates."
   (message "")
-  (let ((keywords (read-input "Keywords (comma separated): ")))
+  (let ((keywords (read-string "Keywords (comma separated): ")))
     (loop for key in (helm-marked-candidates)
 	  do
 	  (save-window-excursion


### PR DESCRIPTION
Because read-input is a deprecated function.
This causes byte-warnings as below.

```
arxiv.el:81:3:Warning: `read-input' is an obsolete function (as of 22.1); use
    `read-string' instead.
```
