### PR TITLE
Allow an optional key for `org-ref-open-notes-at-point'

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -1612,10 +1612,10 @@ Contributed by https://github.com/autosquid."
               (throw 'done nil))))))))
 
 
-(defun org-ref-open-notes-at-point ()
+(defun org-ref-open-notes-at-point (&optional thekey)
   "Open the notes for bibtex key under point."
   (interactive)
-  (let* ((results (org-ref-get-bibtex-key-and-file))
+  (let* ((results (org-ref-get-bibtex-key-and-file thekey))
 	 (key (car results))
 	 (bibfile (cdr results)))
     (save-excursion


### PR DESCRIPTION
This allows one to extend helm-bibtex to access org-ref notes with the following:
``` emacs-lisp
(helm-add-action-to-source
 "Edit org-ref notes"
 'org-ref-open-notes-at-point
 helm-source-bibtex)
```
(See issue #51 for additional discussion.)