### PR TITLE
arxiv.el: Generate BibTeX using arXiv API.

### DIFF
--- a/arxiv.el
+++ b/arxiv.el
@@ -45,7 +45,40 @@
 
 ;; arxiv:cond-mat/0410285
 
-;; * Getting a bibtex entry for an arXiv article
+;; * Getting a bibtex entry for an arXiv article using remote service:
+;; For an arxiv article, there is a link to a NASA ADS page like this:
+;; http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1503.01742
+;; On that page, there is a link to a bibtex entry:
+;; http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2015arXiv150301742H&data_type=BIBTEX&db_key=PRE&nocookieset=1
+;;
+;; It looks like you need to get a Bibliographic code from the arxiv number to
+;; then get the bibtex entry.
+
+(defun arxiv-get-bibliographic-code (arxiv-number)
+  "Get Bibliographic code for ARXIV-NUMBER."
+  (with-current-buffer
+      (url-retrieve-synchronously
+       (concat
+	"http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:"
+	arxiv-number))
+    (search-forward-regexp "name=\\\"bibcode\\\" value=\\\"\\(.*\\)\\\"")
+    (match-string 1)))
+
+(defun arxiv-get-bibtex-entry (arxiv-bibliographic-code)
+  "Get bibtex entry for ARXIV-BIBLIOGRAPHIC-CODE"
+  (with-current-buffer
+      (url-retrieve-synchronously
+       (format
+	"http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=%s&data_type=BIBTEX&db_key=PRE&nocookieset=1"
+	arxiv-bibliographic-code))
+    (goto-char  url-http-end-of-headers)
+    (if (search-forward  "Retrieved 1 abstracts" (point-max) t)
+	(progn
+	  (forward-line)
+	  (buffer-substring (point) (point-max)))
+      (error "Did not get one entry: %s" (buffer-substring (point) (point-max))))))
+
+;; * Getting a bibtex entry for an arXiv article using arXiv API:
 ;; Retrieves the meta data of an article view arXiv's http API,
 ;; extracts the necessary information, and formats a new BibTeX entry.
 
@@ -93,38 +126,6 @@ authors in 'SURNAME, FIRST NAME' format."
           (--map (concat (-last-item it) ", " (s-join " " (-remove-last 'stringp it)))
                  (--map (s-split " +" it) authors))))
 
-;; Other method for making BibTeX, using a remote service:
-;; For an arxiv article, there is a link to a NASA ADS page like this:
-;; http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1503.01742
-;; On that page, there is a link to a bibtex entry:
-;; http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2015arXiv150301742H&data_type=BIBTEX&db_key=PRE&nocookieset=1
-;;
-;; It looks like you need to get a Bibliographic code from the arxiv number to
-;; then get the bibtex entry.
-
-(defun arxiv-get-bibliographic-code (arxiv-number)
-  "Get Bibliographic code for ARXIV-NUMBER."
-  (with-current-buffer
-      (url-retrieve-synchronously
-       (concat
-	"http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:"
-	arxiv-number))
-    (search-forward-regexp "name=\\\"bibcode\\\" value=\\\"\\(.*\\)\\\"")
-    (match-string 1)))
-
-(defun arxiv-get-bibtex-entry (arxiv-bibliographic-code)
-  "Get bibtex entry for ARXIV-BIBLIOGRAPHIC-CODE"
-  (with-current-buffer
-      (url-retrieve-synchronously
-       (format
-	"http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=%s&data_type=BIBTEX&db_key=PRE&nocookieset=1"
-	arxiv-bibliographic-code))
-    (goto-char  url-http-end-of-headers)
-    (if (search-forward  "Retrieved 1 abstracts" (point-max) t)
-	(progn
-	  (forward-line)
-	  (buffer-substring (point) (point-max)))
-      (error "Did not get one entry: %s" (buffer-substring (point) (point-max))))))
 
 (defun arxiv-add-bibtex-entry (arxiv-number bibfile)
   "Add bibtex entry for ARXIV-NUMBER to BIBFILE."

--- a/arxiv.el
+++ b/arxiv.el
@@ -25,6 +25,9 @@
 ;; An Arxiv number might look like: cond-mat/0410285 or 1503.01742
 
 ;;; Code:
+
+(require 's)
+
 ;; * The org-mode link
 ;; this just makes a clickable link that opens the entry.
 (org-add-link-type
@@ -42,39 +45,60 @@
 
 ;; arxiv:cond-mat/0410285
 
-;; * Getting a bibtex entry for an arxiv article
-;; For an arxiv article, there is a link to a NASA ADS page like this:
-;; http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1503.01742
-;; On that page, there is a link to a bibtex entry:
-;; http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2015arXiv150301742H&data_type=BIBTEX&db_key=PRE&nocookieset=1
-;;
-;; It looks like you need to get a Bibliographic code from the arxiv number to
-;; then get the bibtex entry.
+;; * Getting a bibtex entry for an arXiv article
+;; Retrieves the meta data of an article view arXiv's http API,
+;; extracts the necessary information, and formats a new BibTeX entry.
 
-(defun arxiv-get-bibliographic-code (arxiv-number)
-  "Get Bibliographic code for ARXIV-NUMBER."
+(defvar arxiv-entry-format-string "@article{%s,
+  title = {%s},
+  author = {%s},
+  archivePrefix = {arXiv},
+  year = {%s},
+  eprint = {%s},
+  primaryClass = {%s},
+  abstract = {%s},
+  url = {%s},
+}"
+	"Template for BibTeX entries of arXiv articles.")
+
+(defun arxiv-get-bibtex-entry (arxiv-number)
+	"Given an arxiv-number, this function retrieves the meta data
+from arXiv and returns a freshly baked BibTeX entry."
   (with-current-buffer
-      (url-retrieve-synchronously
-       (concat
-	"http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:"
-	arxiv-number))
-    (search-forward-regexp "name=\\\"bibcode\\\" value=\\\"\\(.*\\)\\\"")
-    (match-string 1)))
+			(url-retrieve-synchronously (format "http://export.arxiv.org/api/query?id_list=%s" arxiv-number) t)
+    (let* ((parse-tree (libxml-parse-xml-region
+                       (progn (goto-char 0)
+                              (search-forward "<?xml ")
+                              (match-beginning 0))
+                       (point-max)))
+           (entry (assq 'entry parse-tree))
+					 (authors (--map (nth 2 (nth 2 it))
+                           (--filter (and (listp it) (eq (car it) 'author)) entry)))
+           (year (format-time-string "%Y" (date-to-time (nth 2 (assq 'published entry)))))
+					 (key (arxiv-make-bibtex-key authors year))
+           (title (nth 2 (assq 'title entry)))
+           (names (arxiv-bibtexify-authors authors))
+           (category (cdar (nth 1 (assq 'primary_category entry))))
+           (abstract (s-trim (nth 2 (assq 'summary entry))))
+           (url (nth 2 (assq 'id entry))))
+      (format arxiv-entry-format-string key title names year arxiv-number category abstract url))))
 
-(defun arxiv-get-bibtex-entry (arxiv-bibliographic-code)
-  "Get bibtex entry for ARXIV-BIBLIOGRAPHIC-CODE"
-  (with-current-buffer
-      (url-retrieve-synchronously
-       (format
-	"http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=%s&data_type=BIBTEX&db_key=PRE&nocookieset=1"
-	arxiv-bibliographic-code))
-    (goto-char  url-http-end-of-headers)
-    (if (search-forward  "Retrieved 1 abstracts" (point-max) t)
-	(progn
-	  (forward-line)
-	  (buffer-substring (point) (point-max)))
-      (error "Did not get one entry: %s" (buffer-substring (point) (point-max))))))
+(defun arxiv-make-bibtex-key (authors year)
+	"Given a list of authors and a year, this function return a
+BibTeX key.  If the there are two authors, the format of the key
+is Name1Name2Year; if there are more authors, the format is
+Name1EtAlYear."
+	(let ((surnames (--map (-last-item (s-split " +" it)) authors)))
+		(if (< (length surnames) 3)
+				(concat (s-join "" surnames) year)
+			(concat (car surnames) "EtAl" year))))
 
+(defun arxiv-bibtexify-authors (authors)
+	"Takes a list of author names and returns a string with the
+authors in 'SURNAME, FIRST NAME' format."
+	(s-join " and "
+					(--map (concat (-last-item it) ", " (s-join " " (-remove-last 'stringp it)))
+								 (--map (s-split " +" it) authors))))
 
 (defun arxiv-add-bibtex-entry (arxiv-number bibfile)
   "Add bibtex entry for ARXIV-NUMBER to BIBFILE."
@@ -89,7 +113,7 @@
    (find-file bibfile)
    (goto-char (point-max))
    (when (not (looking-at "^")) (insert "\n"))
-   (insert (arxiv-get-bibtex-entry (arxiv-get-bibliographic-code arxiv-number)))
+   (insert (arxiv-get-bibtex-entry arxiv-number))
    (save-buffer)))
 
 


### PR DESCRIPTION
I didn't test this code thoroughly but so far it works well.  The functions `arxiv-make-bibtex-key` and `arxiv-bibtexify-authors` may also be useful elsewhere in org-ref.  So perhaps they should be moved and renamed.  Also, I'm not sure whether org-ref has any conventions regarding the format of BibTeX keys.  The code generates keys in the format Name2015, Name1Name22015, and Name1EtAl2015.