### PR TITLE
citeproc: Handle no bibliography link in export document

### DIFF
--- a/citeproc/org-ref-citeproc.el
+++ b/citeproc/org-ref-citeproc.el
@@ -956,20 +956,24 @@ documents."
 	      (delete-char -1))
 	    (insert punctuation)))
 
-    ;; replace bibliography link
+    ;; Insert bibliography section at the bibliography link
     (setq bibliography-link (loop for link in (org-element-map
 						  (org-element-parse-buffer) 'link 'identity)
 				  if (string= "bibliography"
 					      (org-element-property :type link))
 				  collect link))
-    (if (> (length bibliography-link) 1)
-	(error "Only one bibliography link allowed"))
-
-    (setq bibliography-link (car bibliography-link))
-    (setf (buffer-substring (org-element-property :begin bibliography-link)
-			    (org-element-property :end bibliography-link))
-	  bibliography-string)))
-
-
+    (pcase (length bibliography-link)
+      ((pred (< 1)) (error "Only one bibliography link allowed"))
+      ((pred (= 1))
+       ;; replace bibliography link
+       (setq bibliography-link (car bibliography-link))
+       (setf (buffer-substring (org-element-property :begin bibliography-link)
+                               (org-element-property :end bibliography-link))
+             bibliography-string))
+      ((pred (= 0))
+       ;; no bibliography link in document
+       (when link-replacements
+         (message "Warning: No bibliography link found although there are citations to process"))
+       ))))
 
 ;;; org-ref-citeproc.el ends here


### PR DESCRIPTION
I often export documents without citations or use the subtree export functionality to only export a small section of a document. Without this change the export will fail if there is no bibliography link in the export document:

```
Debugger entered--Lisp error: (wrong-type-argument integer-or-marker-p nil)
  cl--set-buffer-substring(nil nil "")
  (let* ((v (org-element-property :begin bibliography-link)) (v (org-element-property :end bibliography-link))) (cl--set-buffer-substring v v bibliography-string))
  (let ((link-replacements (let* ((--cl-var-- *orcp-citation-links*) (link nil) (--cl-var-- (orcp-get-citation-replacements)) (repl nil) (--cl-var-- nil)) (while (and (consp --cl-var--) (progn (setq link ...) (consp --cl-var--))) (setq repl (car --cl-var--)) (setq --cl-var-- (cons (list repl ... ...) --cl-var--)) (setq --cl-var-- (cdr --cl-var--)) (setq --cl-var-- (cdr --cl-var--))) (nreverse --cl-var--))) (bibliography-string (orcp-formatted-bibliography)) punctuation trailing-space) (let* ((--cl-var-- (reverse link-replacements)) (repl nil) (start nil) (end nil) (--cl-var--) (--cl-var-- (reverse *orcp-citation-links*)) (link nil)) (while (and (consp --cl-var--) (progn (setq --cl-var-- (car --cl-var--) repl (car-safe (prog1 --cl-var-- ...)) start (car-safe (prog1 --cl-var-- ...)) end (car --cl-var--)) (consp --cl-var--))) (setq link (car --cl-var--)) (if (orcp-get-citation-style (quote chomp-leading-space) (intern (org-element-property :type link))) (progn (goto-char start) (while (and (not ...) (looking-back " ")) (delete-char -1) (setq start (- start 1)) (setq end (- end 1))))) (if (orcp-get-citation-style (quote chomp-trailing-space) (intern (org-element-property :type link))) (progn (goto-char end) (while (looking-at " ") (delete-char 1)))) (setq punctuation nil) (if (orcp-get-citation-style (quote transpose-punctuation) (intern (org-element-property :type link))) (progn (goto-char end) (if (looking-at "\\.\\|,\\|;") (progn (setq punctuation ...) (delete-char 1))))) (goto-char end) (setq trailing-space (if (looking-back " ") " " "")) (let* ((v start) (v end)) (cl--set-buffer-substring v v (concat repl trailing-space))) (if punctuation (progn (goto-char start) (if (thing-at-point (quote whitespace)) (progn (delete-char -1))) (insert punctuation))) (setq --cl-var-- (cdr --cl-var--)) (setq --cl-var-- (cdr --cl-var--))) nil) (setq bibliography-link (let* ((--cl-var-- (org-element-map (org-element-parse-buffer) (quote link) (quote identity))) (link nil) (--cl-var-- nil)) (while (consp --cl-var--) (setq link (car --cl-var--)) (if (string= "bibliography" (org-element-property :type link)) (progn (setq --cl-var-- (cons link --cl-var--)))) (setq --cl-var-- (cdr --cl-var--))) (nreverse --cl-var--))) (if (> (length bibliography-link) 1) (error "Only one bibliography link allowed")) (setq bibliography-link (car bibliography-link)) (let* ((v (org-element-property :begin bibliography-link)) (v (org-element-property :end bibliography-link))) (cl--set-buffer-substring v v bibliography-string)))
  orcp-citeproc(latex)
  run-hook-with-args(orcp-citeproc latex)
```