### PR TITLE
Remove unused variables

### DIFF
--- a/org-ref-latex.el
+++ b/org-ref-latex.el
@@ -42,7 +42,7 @@ The clickable part are the keys.")
 
 (defun org-ref-latex-get-key ()
   "Figure out what key the cursor is on."
-  (let (start end key)
+  (let (start end)
     ;; look back for , or {
     (save-excursion
       (re-search-backward ",\\|{")
@@ -52,7 +52,7 @@ The clickable part are the keys.")
     (save-excursion
       (re-search-forward ",\\|}")
       (setq end (- (point) 1)))
-    (setq key (buffer-substring start end))))
+    (buffer-substring start end)))
 
 
 (defun org-ref-latex-jump-to-bibtex (&optional key)

--- a/org-ref-url-utils.el
+++ b/org-ref-url-utils.el
@@ -141,7 +141,6 @@ reverse-engineered for each publisher."
   (goto-char (nth 1 (event-start event)))
   (x-focus-frame nil)
   (let* ((payload (car (last event)))
-         (type (car payload))
          (url (cadr payload))
 	 (doi (org-ref-scrape-doi url)))
     (if doi


### PR DESCRIPTION
There are two byte-compile warnings about unused variable.

### org-reg-latex.el

```
org-ref-latex.el:43:1:Warning: Unused lexical variable `key
```

### org-ref-url-utils.el

```
org-ref-url-utils.el:138:1:Warning: Unused lexical variable `type
```