### PR TITLE
Define org-in-commented-heading-p only if it isn't defined

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -1082,14 +1082,16 @@ ARG does nothing."
                        (format "\\addbibresource{%s}" keyword)))))
 
 ;;** List of figures
-(defun org-in-commented-heading-p ()
-  "Return t if in a commented section.
+(unless (fboundp 'org-in-commented-heading-p)
+  (defun org-in-commented-heading-p ()
+    "Return t if in a commented section.
 This function gets used below, and the call for it came from
 a pull request.  It doesn't seem to be in org 8.2.10, so I wrote
 one here."
-  (save-excursion
-    (outline-previous-heading)
-    (org-element-property :commentedp (org-element-at-point))))
+    (save-excursion
+      (outline-previous-heading)
+      (org-element-property :commentedp (org-element-at-point))))
+  )
 
 
 (defun org-ref-list-of-figures (&optional arg)


### PR DESCRIPTION
This fixes a problem with newer org-mode versions that already have `org-in-commented-heading-p` defined. My org-mode version is:

```
Org-mode version 8.3.2 (8.3.2-48-g700b8e-elpaplus @ /Users/martin/.emacs.d/elpa/org-plus-contrib-20151214/)
```

If i call `org-todo` to change a TODO-state of a heading I will get the following error because the function definitions are different.

```
Debugger entered--Lisp error: (wrong-number-of-arguments #[nil "\212\302 \210\303\304 ;\203 \305\306	#\202 \307A@	\"+\207" [element property outline-previous-heading :commentedp org-element-at-point get-text-property 0 plist-get] 4 ("/Users/martin/.emacs.d/elpa/org-ref-20151217.349/org-ref.elc" . 28361)] 1)
  org-in-commented-heading-p(t)
  org-todo(nil)

```

My fix is simple: only define `org-in-commented-heading-p` only if it was missing from org-mode.

For reference purposes here is the function in question in my org-mode, it is more complex than the version in org-ref:

```
(defun org-in-commented-heading-p (&optional no-inheritance)
  "Non-nil if point is under a commented heading.
This function also checks ancestors of the current headline,
unless optional argument NO-INHERITANCE is non-nil."
  (cond
   ((org-before-first-heading-p) nil)
   ((let ((headline (nth 4 (org-heading-components))))
      (and headline
	   (let ((case-fold-search nil))
	     (org-string-match-p (concat "^" org-comment-string "\\(?: \\|$\\)")
				 headline)))))
   (no-inheritance nil)
   (t
    (save-excursion (and (org-up-heading-safe) (org-in-commented-heading-p))))))
```