### PR TITLE
Change `org-ref-bibtex-hydra-key-binding`

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -643,7 +643,7 @@ _S_: Sentence case
 
 
 (when org-ref-bibtex-hydra-key-binding
-  (global-set-key org-ref-bibtex-hydra-key-binding 'org-ref-bibtex-hydra/body))
+  (define-key bibtex-mode-map org-ref-bibtex-hydra-key-binding 'org-ref-bibtex-hydra/body))
 
 ;;** Hydra menu for new bibtex entries
 ;; A hydra for adding new bibtex entries.


### PR DESCRIPTION
Would you consider setting `org-ref-bibtex-hydra-key-binding` as a local key binding as I find it only makes sense when editing bibtex files. Global key bindings are precious :)