### PR TITLE
Fix add-to-list for lexical variable issue

### DIFF
--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 (require 'f)
+(require 'cl-lib)
 
 (unless (executable-find "pdftotext")
   (error "pdftotext not found."))
@@ -52,7 +53,7 @@ strings, or nil.
 	(let ((doi (match-string 1)))
 	  (when (s-ends-with? "." doi)
 	    (setq doi (substring doi 0 (- (length doi) 1))))
-	  (add-to-list 'matches doi)))
+	  (cl-pushnew doi matches :test #'equal)))
       matches)))
 
 

--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -60,23 +60,23 @@ strings, or nil.
 (defun org-ref-pdf-doi-candidates (dois)
   "Generate candidate list for helm source.
 Used when multiple dois are found in a pdf file."
-  (loop for doi in dois
-	collect
-	(cons
-	 (plist-get (doi-utils-get-json-metadata doi) :title)
-	 doi)))
+  (cl-loop for doi in dois
+           collect
+           (cons
+            (plist-get (doi-utils-get-json-metadata doi) :title)
+            doi)))
 
 
 (defun org-ref-pdf-add-dois (candidate)
   "Add all entries for CANDIDATE in `helm-marked-candidates'."
-  (loop for doi in (helm-marked-candidates)
-	do
-	(doi-utils-add-bibtex-entry-from-doi
-	 doi
-	 (buffer-file-name))
-	;; this removes two blank lines before each entry.
-	(bibtex-beginning-of-entry)
-	(delete-char -2)))
+  (cl-loop for doi in (helm-marked-candidates)
+           do
+           (doi-utils-add-bibtex-entry-from-doi
+            doi
+            (buffer-file-name))
+           ;; this removes two blank lines before each entry.
+           (bibtex-beginning-of-entry)
+           (delete-char -2)))
 
 
 (defun org-ref-pdf-dnd-func (event)
@@ -156,25 +156,25 @@ This function should only apply when in a bibtex file.
   (find-file bibfile)
   (goto-char (point-max))
 
-  (loop for pdf in (f-entries directory (lambda (f) (f-ext? f "pdf")))
-	do
-	(goto-char (point-max))
-	(insert (format "\n%% [[file:%s]]\n" pdf))
-	(let ((dois (org-ref-extract-doi-from-pdf pdf)))
-	  (cond
-	   ((null dois)
-	    (insert "% No doi found to create entry.\n"))
-	   ((= 1 (length dois))
-	    (doi-utils-add-bibtex-entry-from-doi
-	     (car dois)
-	     (buffer-file-name))
-	    (bibtex-beginning-of-entry)
-	    (delete-char -2))
-	   ;; Multiple DOIs found
-	   (t
-	    (helm :sources `((name . "Select a DOI")
-			     (candidates . ,(org-ref-pdf-doi-candidates dois))
-			     (action . org-ref-pdf-add-dois))))))))
+  (cl-loop for pdf in (f-entries directory (lambda (f) (f-ext? f "pdf")))
+           do
+           (goto-char (point-max))
+           (insert (format "\n%% [[file:%s]]\n" pdf))
+           (let ((dois (org-ref-extract-doi-from-pdf pdf)))
+             (cond
+              ((null dois)
+               (insert "% No doi found to create entry.\n"))
+              ((= 1 (length dois))
+               (doi-utils-add-bibtex-entry-from-doi
+                (car dois)
+                (buffer-file-name))
+               (bibtex-beginning-of-entry)
+               (delete-char -2))
+              ;; Multiple DOIs found
+              (t
+               (helm :sources `((name . "Select a DOI")
+                                (candidates . ,(org-ref-pdf-doi-candidates dois))
+                                (action . org-ref-pdf-add-dois))))))))
 
 (provide 'org-ref-pdf)
 ;;; org-ref-pdf.el ends here


### PR DESCRIPTION
Emacs does not accept add-to-list for lexical variable. There is following error at byte-compiling.

```
In org-ref-extract-doi-from-pdf:
org-ref-pdf.el:54:51:Error: `add-to-list' can't use lexical var `matches'; use
    `push' or `cl-pushnew'
```

And replace cl macros with cl-lib macros in this file.