### PR TITLE
replace journal with booktitle for @inproceedings

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -311,7 +311,7 @@ entry at point."
 
 (defcustom org-ref-bibtex-sort-order
   '(("article"  . ("author" "title" "journal" "volume" "number" "pages" "year" "doi" "url"))
-    ("inproceedings" . ("author" "title" "journal" "volume" "number" "pages" "year" "doi" "url"))
+    ("inproceedings" . ("author" "title" "booktitle" "year" "volume" "number" "pages" "doi" "url"))
     ("book" . ("author" "title" "year" "publisher" "url")))
   "a-list of bibtex entry fields and the order to sort an entry with.
 (entry-type . (list of fields). This is used in


### PR DESCRIPTION
I've also moved the year field up in the sort oder. It's more descriptive for conferences, similarly how volume/number describe the journal.

BTW, in org-bibtex.el, there's a link to a nice reference for the required fields for the various bibtex entries: http://www.andy-roberts.net/res/writing/latex/bibentries.pdf.