### PR TITLE
test for nonascii chars only if 'org-ref-replace-nonascii is called

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -3226,7 +3226,8 @@ specify the key should be kept"
     ;; sort fields within entry
     (org-ref-sort-bibtex-entry)
     ;; check for non-ascii characters
-    (occur "[^[:ascii:]]")))
+    (when (member 'org-ref-replace-nonascii org-ref-clean-bibtex-entry-hook)
+      (occur "[^[:ascii:]]"))))
 
 
 (defun org-ref-get-citation-year (key)


### PR DESCRIPTION
I prefer to keep non-ascii characters in my bibtex files which works well with biblatex. So when I use org-ref-check-bibtex-entry, the occur buffer is superfluous. I've made the call to occur conditional depending the presence of org-ref-replace-nonascii in org-ref-clean-bibtex-entry-hook. The assumption is that if the function has replaced the non-ascii characters, there's no need to call that function. But it seems a bit hacky and maybe you wanted to include the occur call as a sanity check. In that case I would prefer if that could be controlled by an (optional) argument.