### PR TITLE
Autoload interactive functions.

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -438,6 +438,7 @@ until one is found."
 
 ;;** Finally, download the pdf
 
+;;;###autoload
 (defun doi-utils-get-bibtex-entry-pdf ()
   "Download pdf for entry at point if the pdf does not already exist locally.
 The entry must have a doi.  The pdf will be saved
@@ -670,6 +671,7 @@ Also cleans entry using ‘org-ref’, and tries to download the corresponding p
 ;; go to the end, and add the entry. You can sort it later.
 
 
+;;;###autoload
 (defun doi-utils-add-bibtex-entry-from-doi (doi bibfile)
   "Add DOI entry to end of a file in the current directory.
 Pick the file ending with .bib or in
@@ -725,6 +727,7 @@ Argument BIBFILE the bibliography to use."
 (defalias 'doi-add-bibtex-entry 'doi-utils-add-bibtex-entry-from-doi
   "Alias function for convenience.")
 
+;;;###autoload
 (defun doi-utils-doi-to-org-bibtex (doi)
   "Convert a DOI to an ‘org-bibtex’ form and insert it at point."
   (interactive "sDOI: ")
@@ -746,6 +749,7 @@ Argument BIBFILE the bibliography to use."
 ;; There is not bibtex set field function, so I wrote this one.
 
 
+;;;###autoload
 (defun bibtex-set-field (field value &optional nodelim)
   "Set FIELD to VALUE in bibtex file.  create field if it does not exist.
 Optional argument NODELIM see `bibtex-make-field'."
@@ -779,6 +783,7 @@ Optional argument NODELIM see `bibtex-make-field'."
   "Return keys in a PLIST."
   (-slice plist 0 nil 2))
 
+;;;###autoload
 (defun doi-utils-update-bibtex-entry-from-doi (doi)
   "Update fields in a bibtex entry from the DOI.
 Every field will be updated, so previous change will be lost."
@@ -835,6 +840,7 @@ Every field will be updated, so previous change will be lost."
 ;; So, we next develop a function to update the field at point.
 
 
+;;;###autoload
 (defun doi-utils-update-field ()
   "Update the field at point in the bibtex entry.
 Data is retrieved from the doi in the entry."
@@ -874,6 +880,7 @@ Data is retrieved from the doi in the entry."
 ;; that could be considered, but since we usually have a doi, it seems like the
 ;; best way to go for creating the links. Here are the functions.
 
+;;;###autoload
 (defun doi-utils-wos (doi)
   "Open Web of Science entry for DOI."
   (interactive "sDOI: ")
@@ -881,6 +888,7 @@ Data is retrieved from the doi in the entry."
    (format
     "http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:doi/%s" doi)))
 
+;;;###autoload
 (defun doi-utils-wos-citing (doi)
   "Open Web of Science citing articles entry for DOI.
 May be empty if none are found."
@@ -891,6 +899,7 @@ May be empty if none are found."
     doi
     "&svc_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Asch_svc&svc.citing=yes")))
 
+;;;###autoload
 (defun doi-utils-wos-related (doi)
   "Open Web of Science related articles page for DOI."
   (interactive "sDOI: ")
@@ -912,12 +921,14 @@ May be empty if none are found."
 ;; 6. get bibtex entry
 
 
+;;;###autoload
 (defun doi-utils-open (doi)
   "Open DOI in browser."
   (interactive "sDOI: ")
   (browse-url (concat "http://dx.doi.org/" doi)))
 
 
+;;;###autoload
 (defun doi-utils-open-bibtex (doi)
   "Search through variable `reftex-default-bibliography' for DOI."
   (interactive "sDOI: ")
@@ -929,6 +940,7 @@ May be empty if none are found."
         (throw 'file t)))))
 
 
+;;;###autoload
 (defun doi-utils-crossref (doi)
   "Search DOI in CrossRef."
   (interactive "sDOI: ")
@@ -937,6 +949,7 @@ May be empty if none are found."
     "http://search.crossref.org/?q=%s" doi)))
 
 
+;;;###autoload
 (defun doi-utils-google-scholar (doi)
   "Google scholar the DOI."
   (interactive "sDOI: ")
@@ -945,6 +958,7 @@ May be empty if none are found."
     "http://scholar.google.com/scholar?q=%s" doi)))
 
 
+;;;###autoload
 (defun doi-utils-pubmed (doi)
   "Search Pubmed for the DOI."
   (interactive "sDOI: ")
@@ -971,6 +985,7 @@ must take one argument, the doi.")
         ("g" "et bibtex entry" doi-utils-add-bibtex-entry-from-doi)))
 
 
+;;;###autoload
 (defun doi-link-menu (link-string)
   "Generate the link menu message, get choice and execute it.
 Options are stored in `doi-link-menu-funcs'.
@@ -1042,6 +1057,7 @@ Argument LINK-STRING Passed in on link click."
 ;; of candidates, and run a helm command to get the doi.
 
 
+;;;###autoload
 (defun doi-utils-crossref-citation-query ()
   "Query Crossref with the title of the bibtex entry at point.
 Get a list of possible matches.  This opens a helm buffer to
@@ -1120,6 +1136,7 @@ error."
     (json-read-from-string (doi-utils-get-json doi))))
 
 
+;;;###autoload
 (defun doi-utils-debug (doi)
   "Generate an org-buffer showing data about DOI."
   (interactive "sDOI: ")
@@ -1145,6 +1162,7 @@ error."
 ;; You can select a region, e.g. a free form citation, or set of words, or you
 ;; can type the query in by hand.
 
+;;;###autoload
 (defun doi-utils-add-entry-from-crossref-query (query bibtex-file)
   "Search Crossref with QUERY and use helm to select an entry to add to BIBTEX-FILE."
   (interactive (list

--- a/nist-webbook.el
+++ b/nist-webbook.el
@@ -9,6 +9,7 @@
 
 (require 'org)
 
+;;;###autoload
 (defun nist-webbook-formula (formula)
   "Search NIST webbook for FORMULA."
   (interactive "sFormula: ")
@@ -18,6 +19,7 @@
     formula
     "&NoIon=on&Units=SI")))
 
+;;;###autoload
 (defun nist-webbook-name (name)
   "Search NIST webbook for NAME."
   (interactive "sChemical Name: ")

--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -139,6 +139,7 @@ Returns a formatted BibTeX entry."
                  (--map (s-split " +" it) authors))))
 
 
+;;;###autoload
 (defun arxiv-add-bibtex-entry (arxiv-number bibfile)
   "Add bibtex entry for ARXIV-NUMBER to BIBFILE."
   (interactive
@@ -156,6 +157,7 @@ Returns a formatted BibTeX entry."
     (save-buffer)))
 
 
+;;;###autoload
 (defun arxiv-get-pdf (arxiv-number pdf)
   "Retrieve a pdf for ARXIV-NUMBER and save it to PDF."
   (interactive "sarxiv: \nsPDF: ")
@@ -182,6 +184,7 @@ Returns a formatted BibTeX entry."
     (org-open-file pdf)))
 
 
+;;;###autoload
 (defun arxiv-get-pdf-add-bibtex-entry (arxiv-number bibfile pdfdir)
   "Add bibtex entry for ARXIV-NUMBER to BIBFILE.
 Remove troublesome chars from the bibtex key, retrieve a pdf

--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -196,6 +196,7 @@ I like \C-cj."
         ("WR" "Water Research" "Water Res.")))
 
 
+;;;###autoload
 (defun org-ref-bibtex-generate-longtitles ()
   "Generate longtitles.bib which are @string definitions.
 The full journal names are in `org-ref-bibtex-journal-abbreviations'."
@@ -207,6 +208,7 @@ The full journal names are in `org-ref-bibtex-journal-abbreviations'."
                       (nth 1 row))))))
 
 
+;;;###autoload
 (defun org-ref-bibtex-generate-shorttitles ()
   "Generate shorttitles.bib which are @string definitions.
 The abbreviated journal names in `org-ref-bibtex-journal-abbreviations'."
@@ -218,6 +220,7 @@ The abbreviated journal names in `org-ref-bibtex-journal-abbreviations'."
                       (nth 2 row))))))
 
 
+;;;###autoload
 (defun org-ref-stringify-journal-name (&optional key start end)
   "Replace journal name in a bibtex entry with a string.
 The strings are defined in
@@ -246,6 +249,7 @@ START and END allow you to use this with `bibtex-map-entries'"
         (bibtex-fill-entry)))))
 
 
+;;;###autoload
 (defun org-ref-helm-set-journal-string ()
   "Helm interface to set a journal string in a bibtex entry.
 Entries come from `org-ref-bibtex-journal-abbreviations'."
@@ -266,6 +270,7 @@ Entries come from `org-ref-bibtex-journal-abbreviations'."
   (bibtex-clean-entry))
 
 
+;;;###autoload
 (defun org-ref-set-journal-string (full-journal-name)
   "Set a bibtex journal name to the string that represents FULL-JOURNAL-NAME.
 This is defined in `org-ref-bibtex-journal-abbreviations'."
@@ -370,6 +375,7 @@ This is defined in `org-ref-bibtex-journal-abbreviations'."
 	("”" . "\"")))
 
 
+;;;###autoload
 (defun org-ref-replace-nonascii ()
   "Hook function to replace non-ascii characters in a bibtex entry."
   (interactive)
@@ -393,6 +399,7 @@ This is defined in `org-ref-bibtex-journal-abbreviations'."
   "List of words to keep lowercase when changing case in a title.")
 
 
+;;;###autoload
 (defun org-ref-title-case-article (&optional key start end)
   "Convert a bibtex entry article title to title-case.
 The arguments KEY, START and END are optional, and are only there
@@ -440,6 +447,7 @@ all the title entries in articles."
       (bibtex-fill-entry))))
 
 
+;;;###autoload
 (defun org-ref-sentence-case-article (&optional key start end)
   "Convert a bibtex entry article title to sentence-case.
 The arguments KEY, START and END are optional, and are only there
@@ -487,6 +495,7 @@ all the title entries in articles."
       (bibtex-fill-entry))))
 
 ;;* Navigation in bibtex file
+;;;###autoload
 (defun org-ref-bibtex-next-entry (&optional n)
   "Jump to the beginning of the next bibtex entry.
 N is a prefix argument.  If it is numeric, jump that many entries
@@ -506,6 +515,7 @@ forward.  Negative numbers do nothing."
     (bibtex-beginning-of-entry)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-previous-entry (&optional n)
   "Jump to beginning of the previous bibtex entry.
 N is a prefix argument.  If it is numeric, jump that many entries back."
@@ -525,6 +535,7 @@ N is a prefix argument.  If it is numeric, jump that many entries back."
 (add-hook 'bibtex-mode-hook 'org-ref-bibtex-mode-keys)
 
 ;;* Functions to act on an entry with a doi
+;;;###autoload
 (defun org-ref-bibtex-entry-doi ()
   "Get doi from entry at point."
   (interactive)
@@ -533,12 +544,14 @@ N is a prefix argument.  If it is numeric, jump that many entries back."
     (reftex-get-bib-field "doi" (bibtex-parse-entry t))))
 
 
+;;;###autoload
 (defun org-ref-bibtex-wos ()
   "Open bibtex entry in Web Of Science if there is a DOI."
   (interactive)
   (doi-utils-wos (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-wos-citing ()
   "Open citing articles for bibtex entry in Web Of Science if
 there is a DOI."
@@ -546,6 +559,7 @@ there is a DOI."
   (doi-utils-wos-citing (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-wos-related ()
   "Open related articles for bibtex entry in Web Of Science if
 there is a DOI."
@@ -553,24 +567,28 @@ there is a DOI."
   (doi-utils-wos-related (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-crossref ()
   "Open the bibtex entry in Crossref by its doi."
   (interactive)
   (doi-utils-crossref (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-google-scholar ()
   "Open the bibtex entry at point in google-scholar by its doi."
   (interactive)
   (doi-utils-google-scholar (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-pubmed ()
   "Open the bibtex entry at point in Pubmed by its doi."
   (interactive)
   (doi-utils-pubmed (org-ref-bibtex-entry-doi)))
 
 
+;;;###autoload
 (defun org-ref-bibtex-pdf (doi)
   "Open the pdf for the bibtex entry at point.
 Thin wrapper to get `org-ref-bibtex' to open pdf, because it
@@ -696,6 +714,7 @@ I prefer the hydra interfaces above.")
         ("P" "Pubmed" doi-utils-pubmed)
         ("f" "CrossRef" doi-utils-crossref)))
 
+;;;###autoload
 (defun org-ref-bibtex ()
   "Menu command to run in a bibtex entry.
 Functions from `org-ref-bibtex-menu-funcs'.  They all rely on the
@@ -724,6 +743,7 @@ entry having a doi."
 (defalias 'jb 'org-ref-bibtex)
 
 
+;;;###autoload
 (defun org-ref-email-bibtex-entry ()
   "Email current bibtex entry at point and pdf if it exists."
   (interactive)

--- a/org-ref-glossary.el
+++ b/org-ref-glossary.el
@@ -141,6 +141,7 @@ but there could be other :key value pairs."
 	data))))
 
 
+;;;###autoload
 (defun org-ref-add-glossary-entry (label name description)
   "Insert a new glossary entry.
 LABEL is how you refer to it with links.
@@ -298,6 +299,7 @@ Adds a tooltip to the link that is found."
 
 
 ;;* Acronyms
+;;;###autoload
 (defun org-ref-add-acronym-entry (label abbrv full)
   "Add an acronym entry with LABEL.
 ABBRV is the abbreviated form.
@@ -431,6 +433,7 @@ WINDOW and OBJECT are ignored."
 
 
 ;; * Helm command to insert entries
+;;;###autoload
 (defun org-ref-insert-glossary-link ()
   "Helm command to insert glossary and acronym entries as links."
   (interactive)

--- a/org-ref-isbn.el
+++ b/org-ref-isbn.el
@@ -34,6 +34,7 @@
 
 ;; I found this on the web. It can be handy, but the bibtex entry has a lot of stuff in it.
 
+;;;###autoload
 (defun isbn-to-bibtex-lead (isbn)
   "Search lead.to for ISBN bibtex entry.
 You have to copy the entry if it is on the page to your bibtex
@@ -47,6 +48,7 @@ file."
 ;; Here we get isbn metadata and build a bibtex entry.
 ;; http://xisbn.worldcat.org/xisbnadmin/doc/api.htm#getmetadata
 
+;;;###autoload
 (defun isbn-to-bibtex (isbn bibfile)
   "Get bibtex entry for ISBN and insert it into BIBFILE.
 Nothing happens if an entry with the generated key already exists

--- a/org-ref-latex.el
+++ b/org-ref-latex.el
@@ -55,6 +55,7 @@ The clickable part are the keys.")
     (buffer-substring-no-properties start end)))
 
 
+;;;###autoload
 (defun org-ref-latex-debug ()
   (interactive)
   (message-box "%S\n%S\n%S\n%S"
@@ -73,6 +74,7 @@ The clickable part are the keys.")
     (bibtex-search-entry (car results))))
 
 
+;;;###autoload
 (defun org-ref-latex-click ()
   "Jump to entry clicked on."
   (interactive)

--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -104,6 +104,7 @@ Used when multiple dois are found in a pdf file."
 	(delete-char -2)))
 
 
+;;;###autoload
 (defun org-ref-pdf-dnd-func (event)
   "Drag-n-drop support to add a bibtex entry from a pdf file."
   (interactive "e")
@@ -175,6 +176,7 @@ This function should only apply when in a bibtex file.
 (add-to-list 'dnd-protocol-alist '("^file:" . org-ref-pdf-dnd-protocol))
 
 
+;;;###autoload
 (defun org-ref-pdf-dir-to-bibtex (bibfile directory)
   "Create BIBFILE from pdf files in DIRECTORY."
   (interactive "sBibtex file: \nDDirectory: ")
@@ -202,6 +204,7 @@ This function should only apply when in a bibtex file.
 			     (action . org-ref-pdf-add-dois))))))))
 
 
+;;;###autoload
 (defun org-ref-pdf-debug-pdf (pdf-file)
   "Try to debug getting a doi from a pdf.
 Opens a buffer with the pdf converted to text, and `occur' on the

--- a/org-ref-pubmed.el
+++ b/org-ref-pubmed.el
@@ -148,6 +148,7 @@
 
 ;; And we probably want to be able to insert a bibtex entry
 
+;;;###autoload
 (defun pubmed-insert-bibtex-from-pmid (pmid)
   "Insert a bibtex entry at point derived from PMID.
 You must clean the entry after insertion."
@@ -161,6 +162,7 @@ You must clean the entry after insertion."
 ;; undo. I have not used this code for anything, so I am not sure how good the
 ;; xml code is.
 
+;;;###autoload
 (defun pubmed-get-medline-xml (pmid)
   "Get MEDLINE xml for PMID as a string."
   (interactive)
@@ -227,18 +229,21 @@ You must clean the entry after insertion."
 
 ;;* Searching pubmed
 
+;;;###autoload
 (defun pubmed ()
   "Open http://www.ncbi.nlm.nih.gov/pubmed in a browser."
   (interactive)
   (browse-url "http://www.ncbi.nlm.nih.gov/pubmed"))
 
 
+;;;###autoload
 (defun pubmed-advanced ()
   "Open http://www.ncbi.nlm.nih.gov/pubmed/advanced in a browser."
   (interactive)
   (browse-url "http://www.ncbi.nlm.nih.gov/pubmed/advanced"))
 
 
+;;;###autoload
 (defun pubmed-simple-search (query)
   "Open QUERY in Pubmed in a browser."
   (interactive "sQuery: ")

--- a/org-ref-scifinder.el
+++ b/org-ref-scifinder.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 
+;;;###autoload
 (defun scifinder ()
   "Open https://scifinder.cas.org/scifinder/view/scifinder/scifinderExplore.jsf in a browser."
   (interactive)

--- a/org-ref-scopus.el
+++ b/org-ref-scopus.el
@@ -79,6 +79,7 @@ Requires `*scopus-api-key*' to be defined."
     (car (xml-node-children (car (xml-get-children entry 'eid))))))
 
 
+;;;###autoload
 (defun scopus-related-by-keyword-url (doi)
   "Return a Scopus url to articles related by keyword for DOI."
   (interactive)
@@ -87,6 +88,7 @@ Requires `*scopus-api-key*' to be defined."
     (when eid (format "http://www.scopus.com/search/submit/mlt.url?eid=%s&src=s&all=true&origin=recordpage&method=key&zone=relatedDocuments" eid))))
 
 
+;;;###autoload
 (defun scopus-related-by-author-url (doi)
   "Return a Scopus url to articles related by author for DOI."
   (interactive)
@@ -95,6 +97,7 @@ Requires `*scopus-api-key*' to be defined."
     (when eid (format "http://www.scopus.com/search/submit/mlt.url?eid=%s&src=s&all=true&origin=recordpage&method=aut&zone=relatedDocuments" eid))))
 
 
+;;;###autoload
 (defun scopus-related-by-references-url (doi)
   "Return a Scopus url to articles related by references for DOI."
   (interactive)
@@ -108,6 +111,7 @@ Requires `*scopus-api-key*' to be defined."
   (format "http://www.scopus.com/results/citedbyresults.url?sort=plf-f&cite=%s&src=s&imp=t&sot=cite&sdt=a&sl=0&origin=recordpage" (scopus-doi-to-eid doi)))
 
 
+;;;###autoload
 (defun scopus-open-eid (eid)
   "Open article with EID in browser."
   (interactive "sEID: ")
@@ -119,6 +123,7 @@ Requires `*scopus-api-key*' to be defined."
   (browse-url "http://www.scopus.com"))
 
 
+;;;###autoload
 (defun scopus-basic-search (query)
   "Open QUERY as a basic title-abstract-keyword search at scopus.com."
   (interactive "sQuery: ")
@@ -129,6 +134,7 @@ Requires `*scopus-api-key*' to be defined."
     (url-hexify-string query))))
 
 
+;;;###autoload
 (defun scopus-advanced-search (query)
   "Open QUERY as an advanced search at scopus.com."
   (interactive "sQuery: ")

--- a/org-ref-url-utils.el
+++ b/org-ref-url-utils.el
@@ -179,6 +179,7 @@ A doi will be either doi:10.xxx  or 10.xxx."
 
 ;; You can use this to see if there are any DOIs in a URL, and to use re-builder
 ;; to add new patterns to `org-ref-doi-regexps'.
+;;;###autoload
 (defun org-ref-url-debug-url (url)
   "Open a buffer to URL with all doi patterns highlighted."
   (interactive)
@@ -188,6 +189,7 @@ A doi will be either doi:10.xxx  or 10.xxx."
    (mapconcat 'identity org-ref-doi-regexps "\\|")))
 
 
+;;;###autoload
 (defun org-ref-url-dnd-debug (event)
   "Drag-n-drop function to debug a url."
   (interactive "e")
@@ -211,6 +213,7 @@ A doi will be either doi:10.xxx  or 10.xxx."
 	  (delete-char -2))))
 
 
+;;;###autoload
 (defun org-ref-url-dnd-all (event)
   "Drag-n-drop function to get all DOI bibtex entries for a url.
 You probably do not want to do this since the DOI patterns are
@@ -245,6 +248,7 @@ not perfect, and some hits are not actually DOIs."
 	  (bibtex-clean-entry))))
 
 
+;;;###autoload
 (defun org-ref-url-dnd-first (event)
   "Drag-n-drop function to download the first DOI in a url."
   (interactive "e")

--- a/org-ref-wos.el
+++ b/org-ref-wos.el
@@ -62,6 +62,7 @@
 	   (or desc link))))))
 
 
+;;;###autoload
 (defun wos-search ()
   "Open the word at point or selection in Web of Science as a topic query."
   ;; the url was derived from this page: http://wokinfo.com/webtools/searchbox/
@@ -75,6 +76,7 @@
              (thing-at-point 'word)))))
 
 
+;;;###autoload
 (defun wos ()
   "Open Web of Science search page in a browser."
   (interactive)

--- a/org-ref.el
+++ b/org-ref.el
@@ -381,6 +381,7 @@ have fields sorted alphabetically."
                          (?n . "nocite:%l"))))))
 
 
+;;;###autoload
 (defun org-ref-version ()
   "Provide a version string for org-ref.
 Copies the string to the clipboard."
@@ -421,6 +422,7 @@ Copies the string to the clipboard."
   "Variable to store the link message timer in.")
 
 
+;;;###autoload
 (defun org-ref-show-link-messages ()
   "Turn on link messages.
 You will see a message in the minibuffer when on a cite, ref or
@@ -431,6 +433,7 @@ label link."
             (run-with-idle-timer 0.5 t 'org-ref-link-message))))
 
 
+;;;###autoload
 (defun org-ref-cancel-link-messages ()
   "Stop showing messages in minibuffer when on a link."
   (interactive)
@@ -461,6 +464,7 @@ If so return the position for `goto-char'."
         nil))))
 
 
+;;;###autoload
 (defun org-ref-mouse-message ()
   "Display message for link under mouse cursor."
   (interactive)
@@ -481,6 +485,7 @@ If so return the position for `goto-char'."
   "How often to run the mouse message timer in seconds.")
 
 
+;;;###autoload
 (defun org-ref-mouse-messages-on ()
   "Turn on mouse messages."
   (interactive)
@@ -491,6 +496,7 @@ If so return the position for `goto-char'."
                          'org-ref-mouse-message))))
 
 
+;;;###autoload
 (defun org-ref-mouse-messages-off ()
   "Turn off mouse messages."
   (interactive)
@@ -908,6 +914,7 @@ Use SORT to specify alphabetical order by key."
     keys))
 
 
+;;;###autoload
 (defun org-ref-bibliography (&optional sort)
   "Create a new buffer with a bibliography.
 If SORT is non-nil it is alphabetically sorted by key
@@ -1229,6 +1236,7 @@ ARG does nothing."
   (format "bibliography:%s" (read-file-name "enter file: " nil nil t)))
 
 
+;;;###autoload
 (defun org-ref-insert-bibliography-link ()
   "Insert a bibliography with completion."
   (interactive)
@@ -1311,6 +1319,7 @@ unless optional argument NO-INHERITANCE is non-nil."
      (t
       (save-excursion (and (org-up-heading-safe) (org-in-commented-heading-p)))))))
 
+;;;###autoload
 (defun org-ref-list-of-figures (&optional arg)
   "Generate buffer with list of figures in them.
 ARG does nothing.
@@ -1367,6 +1376,7 @@ Ignore figures in COMMENTED sections."
      (format "\\listoffigures")))))
 
 ;;** List of tables
+;;;###autoload
 (defun org-ref-list-of-tables (&optional arg)
   "Generate a buffer with a list of tables.
 ARG does nothing."
@@ -1610,6 +1620,7 @@ This is used to complete ref links and in helm menus."
                 (org-ref-get-custom-ids))))))
 
 
+;;;###autoload
 (defun org-ref-helm-insert-label-link ()
   "Insert a label link.
 Helm just shows you what labels already exist.  If you are on a
@@ -1694,12 +1705,14 @@ Optional argument ARG Does nothing."
     (format "ref:%s" label)))
 
 
+;;;###autoload
 (defun org-ref-insert-ref-link ()
   "Completion function for a ref link."
   (interactive)
   (insert (org-ref-complete-link)))
 
 
+;;;###autoload
 (defun org-ref-helm-insert-ref-link ()
   "Helm menu to insert ref links to labels in the document.
 If you are on link, replace with newly selected label.  Use
@@ -1826,6 +1839,7 @@ Optional argument ARG Does nothing."
     (format "ref:%s" label)))
 
 
+;;;###autoload
 (defun org-pageref-insert-ref-link ()
   "Insert a pageref link with completion."
   (interactive)
@@ -2053,6 +2067,7 @@ Argument KEY is the bibtex key."
                   key))))))
 
 
+;;;###autoload
 (defun org-ref-open-pdf-at-point ()
   "Open the pdf for bibtex key under point if it exists."
   (interactive)
@@ -2064,6 +2079,7 @@ Argument KEY is the bibtex key."
       (message "no pdf found for %s" key))))
 
 
+;;;###autoload
 (defun org-ref-open-url-at-point ()
   "Open the url for bibtex key under point."
   (interactive)
@@ -2091,6 +2107,7 @@ Argument KEY is the bibtex key."
               (throw 'done nil))))))))
 
 
+;;;###autoload
 (defun org-ref-open-notes-at-point (&optional thekey)
   "Open the notes for bibtex key under point in a cite link in a buffer.
 Can also be called with THEKEY in a program."
@@ -2098,6 +2115,7 @@ Can also be called with THEKEY in a program."
   (funcall org-ref-notes-function thekey))
 
 
+;;;###autoload
 (defun org-ref-citation-at-point ()
   "Give message of current citation at point."
   (interactive)
@@ -2113,6 +2131,7 @@ Can also be called with THEKEY in a program."
                       (org-ref-bib-citation))))))
 
 
+;;;###autoload
 (defun org-ref-open-citation-at-point ()
   "Open bibtex file to key at point."
   (interactive)
@@ -2139,6 +2158,7 @@ function, and functions are conditionally added to it.")
   "User-defined functions to run on bibtex key at point.")
 
 
+;;;###autoload
 (defun org-ref-copy-entry-as-summary ()
   "Copy the bibtex entry for the citation at point as a summary."
   (interactive)
@@ -2147,6 +2167,7 @@ function, and functions are conditionally added to it.")
     (kill-new (org-ref-bib-citation))))
 
 
+;;;###autoload
 (defun org-ref-copy-entry-at-point-to-file ()
   "Copy the bibtex entry for the citation at point to NEW-FILE.
 Prompt for NEW-FILE includes bib files in
@@ -2192,36 +2213,42 @@ directory.  You can also specify a new file."
 
 
 ;;**** functions that operate on key at point for click menu
+;;;###autoload
 (defun org-ref-wos-at-point ()
   "Open the doi in wos for bibtex key under point."
   (interactive)
   (doi-utils-wos (org-ref-get-doi-at-point)))
 
 
+;;;###autoload
 (defun org-ref-wos-citing-at-point ()
   "Open the doi in wos citing articles for bibtex key under point."
   (interactive)
   (doi-utils-wos-citing (org-ref-get-doi-at-point)))
 
 
+;;;###autoload
 (defun org-ref-wos-related-at-point ()
   "Open the doi in wos related articles for bibtex key under point."
   (interactive)
   (doi-utils-wos-related (org-ref-get-doi-at-point)))
 
 
+;;;###autoload
 (defun org-ref-google-scholar-at-point ()
   "Open the doi in google scholar for bibtex key under point."
   (interactive)
   (doi-utils-google-scholar (org-ref-get-doi-at-point)))
 
 
+;;;###autoload
 (defun org-ref-pubmed-at-point ()
   "Open the doi in pubmed for bibtex key under point."
   (interactive)
   (doi-utils-pubmed (org-ref-get-doi-at-point)))
 
 
+;;;###autoload
 (defun org-ref-crossref-at-point ()
   "Open the doi in crossref for bibtex key under point."
   (interactive)
@@ -2229,6 +2256,7 @@ directory.  You can also specify a new file."
 
 ;;*** Minibuffer menu
 
+;;;###autoload
 (defun org-ref-cite-onclick-minibuffer-menu (&optional link-string)
   "Action when a cite link is clicked on.
 Provides a menu of context sensitive actions.  If the bibtex entry
@@ -2437,6 +2465,7 @@ text]]."
    (t (format "[%s]" desc))))
 
 
+;;;###autoload
 (defun org-ref-define-citation-link (type &optional key)
   "Add a citation link of TYPE for `org-ref'.
 With optional KEY, set the reftex binding.  For example:
@@ -2471,6 +2500,7 @@ citez link, with reftex key of z, and the completion function."
   (org-ref-define-citation-link type))
 
 
+;;;###autoload
 (defun org-ref-insert-cite-link (alternative-cite)
   "Insert a default citation link using reftex.
 If you are on a link, it appends to the end of the link,
@@ -2515,12 +2545,14 @@ arg (ALTERNATIVE-CITE) to get a menu of citation types."
       (reftex-citation))))
 
 
+;;;###autoload
 (defun org-ref-insert-cite-with-completion (type)
   "Insert a cite link of TYPE with completion."
   (interactive (list (ido-completing-read "Type: " org-ref-cite-types)))
   (insert (funcall (intern (format "org-%s-complete-link" type)))))
 
 
+;;;###autoload
 (defun org-ref-store-bibtex-entry-link ()
   "Save a citation link to the current bibtex entry.  Save in the default link type."
   (interactive)
@@ -2545,6 +2577,7 @@ arg (ALTERNATIVE-CITE) to get a menu of citation types."
      (format "\\index{%s}" path)))))
 
 ;; this will generate a temporary index of entries in the file when clicked on.
+;;;###autoload
 (defun org-ref-index (&optional path)
   "Open an *index* buffer with links to index entries.
 PATH is required for the org-link, but it does nothing here."
@@ -2665,6 +2698,7 @@ This assumes you are in an article."
               (format " <a href=\"http://dx.doi.org/%s\">doi</a>" doi)))))
 
 ;;** Open pdf in bibtex entry
+;;;###autoload
 (defun org-ref-open-bibtex-pdf ()
   "Open pdf for a bibtex entry, if it exists.
 assumes point is in
@@ -2682,6 +2716,7 @@ the entry of interest in the bibfile.  but does not check that."
         (ding)))))
 
 ;;** Open notes from bibtex entry
+;;;###autoload
 (defun org-ref-open-bibtex-notes ()
   "From a bibtex entry, open the notes if they exist.
 If the notes do not exist, then create a heading.
@@ -2747,6 +2782,7 @@ construct the heading by hand."
 	  (save-buffer))))))
 
 
+;;;###autoload
 (defun org-ref-open-notes-from-reftex ()
   "Call reftex, and open notes for selected entry."
   (interactive)
@@ -2763,6 +2799,7 @@ construct the heading by hand."
 
 
 ;;** Open bibtex entry in browser
+;;;###autoload
 (defun org-ref-open-in-browser ()
   "Open the bibtex entry at point in a browser using the url field or doi field."
   (interactive)
@@ -2784,6 +2821,7 @@ construct the heading by hand."
 
 
 ;;** Build a pdf of the bibtex file
+;;;###autoload
 (defun org-ref-build-full-bibliography ()
   "Build pdf of all bibtex entries, and open it."
   (interactive)
@@ -2815,6 +2853,7 @@ construct the heading by hand."
 
 ;;** Extract bibtex entries in org-file
 
+;;;###autoload
 (defun org-ref-extract-bibtex-entries ()
   "Extract the bibtex entries in the current buffer into a src block.
 
@@ -2889,6 +2928,7 @@ If no bibliography is in the buffer the variable
     (if found i nil)))
 
 
+;;;###autoload
 (defun org-ref-find-bad-citations ()
   "Create a list of citation keys that do not have a matching bibtex entry.
 List is displayed in an `org-mode' buffer using the known bibtex
@@ -3219,6 +3259,7 @@ at the end of you file.
                                   (funcall x))))))))
 
 ;;** Find non-ascii charaters
+;;;###autoload
 (defun org-ref-find-non-ascii-characters ()
   "Find non-ascii characters in the buffer.  Useful for cleaning up bibtex files."
   (interactive)
@@ -3226,6 +3267,7 @@ at the end of you file.
 
 
 ;;** Sort fields in a bibtex entry
+;;;###autoload
 (defun org-ref-sort-bibtex-entry ()
   "Sort fields of entry in standard order and downcase them."
   (interactive)
@@ -3349,6 +3391,7 @@ at the end of you file.
       (kill-new key)))
 
 
+;;;###autoload
 (defun org-ref-clean-bibtex-entry ()
   "Clean and replace the key in a bibtex entry.
 See functions in `org-ref-clean-bibtex-entry-hook'."
@@ -3375,6 +3418,7 @@ See functions in `org-ref-clean-bibtex-entry-hook'."
       (prog1 (reftex-get-bib-field "year" (bibtex-parse-entry t))))))
 
 ;;** Sort cite in cite link
+;;;###autoload
 (defun org-ref-sort-citation-link ()
   "Replace link at point with sorted link by year."
   (interactive)
@@ -3402,6 +3446,7 @@ See functions in `org-ref-clean-bibtex-entry-hook'."
   keys)
 
 
+;;;###autoload
 (defun org-ref-swap-citation-link (direction)
   "Move citation at point in DIRECTION +1 is to the right, -1 to the left."
   (interactive)
@@ -3442,6 +3487,7 @@ See functions in `org-ref-clean-bibtex-entry-hook'."
 (add-hook 'org-shiftleft-hook (lambda () (org-ref-swap-citation-link -1)))
 
 ;;** C-arrow navigation of cite keys
+;;;###autoload
 (defun org-ref-next-key ()
   "Move cursor to the next cite key when on a cite link.
 Otherwise run `right-word'. If the cursor moves off the link,
@@ -3459,6 +3505,7 @@ move to the beginning of the next cite link after this one."
     (right-word)))
 
 
+;;;###autoload
 (defun org-ref-previous-key ()
   "Move cursor to the previous cite key when on a cite link.
 Otherwise run `left-word'. If cursor moves off the link, jump to
@@ -3534,6 +3581,7 @@ the end of the next cite link before this one."
       (throw 'result "!!! NO CONTEXT FOUND !!!"))))
 
 
+;;;###autoload
 (defun org-ref-link-message ()
   "Print a minibuffer message about the link that point is on."
   (interactive)
@@ -3724,6 +3772,7 @@ These are in the keywords field, and are comma or semicolon separated."
       keywords)))
 
 
+;;;###autoload
 (defun org-ref-set-bibtex-keywords (keywords &optional arg)
   "Add KEYWORDS to a bibtex entry.
 If KEYWORDS is a list, it is converted to a comma-separated
@@ -3748,6 +3797,7 @@ keywords.  Optional argument ARG prefix arg to replace keywords."
   (save-buffer))
 
 
+;;;###autoload
 (defun helm-tag-bibtex-entry ()
   "Helm interface to add keywords to a bibtex entry.
 Run this with the point in a bibtex entry."
@@ -4261,6 +4311,7 @@ _o_: Open entry   _e_: Email entry and pdf
 
 
 ;;* org-ref-help
+;;;###autoload
 (defun org-ref-help ()
   "Open the `org-ref' manual."
   (interactive)
@@ -4297,6 +4348,7 @@ _o_: Open entry   _e_: Email entry and pdf
   "Evaluate BODY and return a string."
   `(format "%s" (progn ,@body)))
 
+;;;###autoload
 (defun org-ref-debug ()
   "Print some debug information to a buffer."
   (interactive)

--- a/x2bib.el
+++ b/x2bib.el
@@ -49,6 +49,7 @@
 ;; you should probably inspect the entries, and do other bibtex file compliance
 ;; checks.
 
+;;;###autoload
 (defun ris2bib (risfile &optional verbose)
   "Convert RISFILE to bibtex and insert at point.
 Without a prefix arg, stderr is diverted.
@@ -83,6 +84,7 @@ If VERBOSE is non-nil show command output."
 ;; them to a file. If you choose Pubmed XML as the format, then you can use this
 ;; function to convert it to bibtex.
 
+;;;###autoload
 (defun medxml2bib (medfile &optional verbose)
   "Convert MEDFILE (in Pubmed xml) to bibtex and insert at point.
 Without a prefix arg, stderr is diverted.
@@ -116,6 +118,7 @@ Display output if VERBOSE is non-nil."
 ;; Finally, after you put the new entries in, you probably need to do some clean
 ;; up actions. This little function does that.
 
+;;;###autoload
 (defun clean-entries ()
   "Map over bibtex entries and clean them."
   (interactive)


### PR DESCRIPTION
Autoload allows the function to exist without Emacs needing to read the file and the file is read only when the function is actually used.

This should improve loading times for users who defer the loading of packages.

Note that I don't write in Lisp very much, so I hope my usage of `autoload` is correct.  I have only added the `autoload` directive to functions marked as `interactive`.