### PR TITLE
Adapt org-ref-notes-function to accept a key

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -131,7 +131,7 @@ codes."
 
 
 (defcustom org-ref-notes-function
-  (lambda ()
+  (lambda (thekey)
     (let* ((results (org-ref-get-bibtex-key-and-file thekey))
            (key (car results))
            (bibfile (cdr results)))


### PR DESCRIPTION
In aa3c91c56be2489f1ad126f69723e97a39d5ae7 org-ref-open-notes-at-point was changed
to call org-ref-notes-function with theKey as argument.

The default of org-ref-notes-function was not changed to incorporate this leading to a
error when called. (wrong number of arguments).

This pull request should fix the issue.