### PR TITLE
save all bibtex buffers

### DIFF
--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -607,6 +607,7 @@ change the key at point to the selected keys."
 (defun org-ref-helm-cite-init ()
   "Initializes the source, setting bibtex files from the
 originating buffer, and mode of originating buffer."
+  (org-ref-save-all-bibtex-buffers)
   (setq org-ref-bibtex-files (org-ref-find-bibliography))
   ;; save major-mode we came from so we can do context specific things.
   (setq org-ref-helm-cite-from major-mode)

--- a/org-ref.el
+++ b/org-ref.el
@@ -3958,6 +3958,15 @@ change the key at point to the selected keys."
   ;; return empty string for helm
   "")
 
+(defun org-ref-save-all-bibtex-buffers ()
+  "Save all bibtex-buffers."
+  ; moved from inside `org-ref-helm-insert-cite-link' so it can also be used elsewhere
+  (cl-loop for buffer in (buffer-list)
+	   do
+	   (with-current-buffer buffer
+	     (when (and (buffer-file-name) (f-ext? (buffer-file-name) "bib"))
+	       (save-buffer)))))
+  
 
 ;;;###autoload
 (defun org-ref-helm-insert-cite-link (arg)
@@ -3968,11 +3977,7 @@ With two prefix ARGs, insert a label link."
   ;; save all bibtex buffers so we get the most up-to-date selection. I find
   ;; that I often edit a bibliography and forget to save it, so the newest entry
   ;; does not show in helm-bibtex.
-  (cl-loop for buffer in (buffer-list)
-        do
-        (with-current-buffer buffer
-          (when (and (buffer-file-name) (f-ext? (buffer-file-name) "bib"))
-            (save-buffer))))
+  (org-ref-save-all-bibtex-buffers)
   (cond
    ((equal arg nil)
     (let ((helm-bibtex-bibliography (org-ref-find-bibliography)))


### PR DESCRIPTION
I think it could be useful to save all bibtex buffers when org-ref-helm-cite initializes, as is already the case with org-ref-helm-insert-cite-link.