### PR TITLE
Specify group attribute for customize

### DIFF
--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -47,7 +47,8 @@
 
 (defcustom org-ref-notes-directory
   "~/Dropbox/bibliography/helm-cite-notes/"
-  "Directory for notes to go in.")
+  "Directory for notes to go in."
+  :group 'org-ref)
 
 
 ;;* Variables


### PR DESCRIPTION
And this also fixes byte-compile warning.

```
org-ref-helm-cite.el:48:1:Warning: defcustom for `org-ref-notes-directory'
    fails to specify containing group                                                                           
org-ref-helm-cite.el:48:1:Warning: defcustom for `org-ref-notes-directory'
    fails to specify containing group
```