### PR TITLE
Bugfix in creating notes for new bibtex entries

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -653,17 +653,20 @@ Also cleans entry using ‘org-ref’, and tries to download the corresponding p
   ;; set date added for the record
   (when doi-utils-timestamp-format-function
     (bibtex-set-field doi-utils-timestamp-field
-		      (funcall doi-utils-timestamp-format-function)))
+          (funcall doi-utils-timestamp-format-function)))
   (ignore-errors
     (if (bibtex-key-in-head nil)
-	(org-ref-clean-bibtex-entry t)
+  (org-ref-clean-bibtex-entry t)
       (org-ref-clean-bibtex-entry)))
   ;; try to get pdf
   (when doi-utils-download-pdf
     (doi-utils-get-bibtex-entry-pdf))
 
   (save-selected-window
-    (funcall doi-utils-make-notes-function)))
+    (org-ref-open-bibtex-notes)
+    ;;(save-buffer)                         ; helm-bibtex-edit-notes performs a search in the buffer that fails if the buffer has not been saved
+    ;;(funcall doi-utils-make-notes-function)
+    ))
 
 
 ;; It may be you are in some other place when you want to add a bibtex entry.


### PR DESCRIPTION
Function 'doi-utils-insert-bibtex-entry-from-doi' would fail to create a
note when adding a bibtex entry.
Solved by substituting a function of helm-bibtex with
'org-ref-open-bibtex-notes'

The old function would fail because the bibliography buffer was not
saved, therefore it couldn't find the requested key.
Even if fixing the error by saving the buffer before calling it, the helm-bibtex function
would write the note in a different buffer, so I decided to substitute it