### PR TITLE
A couple of changes in handling pdfs

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -59,6 +59,12 @@
   :type 'boolean
   :group 'doi-utils)
 
+(defcustom doi-utils-open-pdf-after-download
+  nil
+  "Open PDF after adding bibtex entries."
+  :type 'boolean
+  :group 'doi-utils)
+
 (defcustom doi-utils-timestamp-field
   "DATE_ADDED"
   "The bibtex field to store the date when an entry has been added."
@@ -480,11 +486,11 @@ at the end."
                 (if (not (string= (buffer-substring 1 (min 6 (point-max))) "%PDF-"))
                     (progn
                       (delete-file pdf-file)
-		      (message "No pdf was downloaded.")
-		      (browse-url pdf-url))
+          (message "No pdf was downloaded.")
+          (browse-url pdf-url))
                   (message "%s saved" pdf-file)))
 
-              (when (file-exists-p pdf-file)
+              (when (and doi-utils-open-pdf-after-download (file-exists-p pdf-file))
                 (org-open-file pdf-file))))
         pdf-file))))
 

--- a/org-ref.el
+++ b/org-ref.el
@@ -61,6 +61,12 @@
   :tag "Org Ref"
   :group 'org)
 
+(defcustom org-ref-clean-bibtex-key-function
+  (lambda (key)
+    (replace-regexp-in-string ":" "" key))
+  "Clean a bibtex key from unwanted characters"
+  :type 'function
+  :group 'org-ref)
 
 (defcustom org-ref-bibliography-notes
   nil
@@ -3380,22 +3386,22 @@ at the end of you file.
 
 (defun orcb-key ()
   "Replace the key in the entry."
-  (let ((key (bibtex-generate-autokey)))
+  (let ((key (funcall org-ref-clean-bibtex-key-function (bibtex-generate-autokey))))
       ;; first we delete the existing key
       (bibtex-beginning-of-entry)
       (re-search-forward bibtex-entry-maybe-empty-head)
       (if (match-beginning bibtex-key-in-head)
-	  (delete-region (match-beginning bibtex-key-in-head)
-			 (match-end bibtex-key-in-head)))
+    (delete-region (match-beginning bibtex-key-in-head)
+       (match-end bibtex-key-in-head)))
       ;; check if the key is in the buffer
       (when (save-excursion
-	      (bibtex-search-entry key))
-	(save-excursion
-	  (bibtex-search-entry key)
-	  (bibtex-copy-entry-as-kill)
-	  (switch-to-buffer-other-window "*duplicate entry*")
-	  (bibtex-yank))
-	(setq key (bibtex-read-key "Duplicate Key found, edit: " key)))
+        (bibtex-search-entry key))
+  (save-excursion
+    (bibtex-search-entry key)
+    (bibtex-copy-entry-as-kill)
+    (switch-to-buffer-other-window "*duplicate entry*")
+    (bibtex-yank))
+  (setq key (bibtex-read-key "Duplicate Key found, edit: " key)))
 
       (insert key)
       (kill-new key)))


### PR DESCRIPTION
Added variable 'doi-utils-open-pdf-after-download' that controls whether to display or not a PDF after download.
Added function 'org-ref-clean-bibtex-key-function' that can modify an entry key. It can be useful to reformat the key or remove unwanted character. For example my owncloud doesn't like file names with colons in it.