### PR TITLE
Add ivy actions

### DIFF
--- a/citeproc/author-year.el
+++ b/citeproc/author-year.el
@@ -6,7 +6,7 @@
 
 ;;; Code:
 
-(defvar citation-style
+(setq citation-style
   '((label . orcp-citation-author-year-label)
     (prefix . "(")
     (suffix . ")")
@@ -20,12 +20,11 @@
 		 (prefix . "")
 		 (suffix . " ")
 		 (chomp-leading-space . nil)
-		 )))
-  "The author-year citation style.")
+		 ))))
 
 
 
-(defvar bibliography-style
+(setq bibliography-style
   '((sort . nil)
     (hanging-indent . 3)
     (justification . full)
@@ -77,8 +76,7 @@
     ;; Formatting of entries
     (entries . ((article . (author title journal volume pages year doi))
 		(book . (author title year))
-		(misc . (author title url doi)))))
-  "The author-year bibliography style.")
+		(misc . (author title url doi))))))
 
 (provide 'author-year)
 

--- a/citeproc/unsrt-footnote.el
+++ b/citeproc/unsrt-footnote.el
@@ -6,7 +6,7 @@
 
 ;;; Code:
 
-(defvar citation-style
+(setq citation-style
   '((label . orcp-footnote-label)
     (prefix . "")
     (suffix . "")
@@ -22,11 +22,10 @@
 			 *orcp-unique-entries*)))
 		(> i2 i1))))
     (delimiter . ", ")
-    (vertical-align . baseline))
-  "Footnote citations style")
+    (vertical-align . baseline)))
 
 
-(defvar bibliography-style
+(setq bibliography-style
   '((sort . nil)
     (hanging-indent . 3)
     (justification . full)
@@ -80,8 +79,7 @@
 		(techreport . (author title institution year))
 		(mastersthesis . (author title school year))
 		(phdthesis . (author title school year))
-		(t . (author title year)))))
-  "Footnote bibliography style.")
+		(t . (author title year))))))
 
 (provide 'unsrt)
 

--- a/citeproc/unsrt-paren.el
+++ b/citeproc/unsrt-paren.el
@@ -6,7 +6,7 @@
 
 ;;; Code:
 
-(defvar citation-style
+(setq citation-style
   '((label . orcp-citation-number-label)
     (prefix . "(")
     (suffix . ")")
@@ -43,11 +43,10 @@
 		 (prefix . "")
 		 (suffix . "")
 		 (chomp-leading-space . nil)
-		 (chomp-trailing-space . nil))))
-  "Unsorted with () citation style.")
+		 (chomp-trailing-space . nil)))))
 
 
-(defvar bibliography-style
+(setq bibliography-style
   '((sort . nil)
     (hanging-indent . 3)
     (justification . full)
@@ -101,8 +100,7 @@
 		(techreport . (author title institution year))
 		(mastersthesis . (author title school year))
 		(phdthesis . (author title school year))
-		(t . (author title year)))))
-  "Unsrted wiht () bibliography style.")
+		(t . (author title year))))))
 
 (provide 'unsrt-paren)
 

--- a/citeproc/unsrt.el
+++ b/citeproc/unsrt.el
@@ -6,7 +6,7 @@
 
 ;;; Code:
 
-(defvar citation-style
+(setq citation-style
   '((label . orcp-citation-number-label)
     (prefix . "")
     (suffix . "")
@@ -43,11 +43,10 @@
 		 (prefix . "")
 		 (suffix . " ")
 		 (chomp-leading-space . nil)
-		 (chomp-trailing-space . nil))))
-  "Unsrt citation style.")
+		 (chomp-trailing-space . nil)))))
 
 
-(defvar bibliography-style
+(setq bibliography-style
   '((sort . nil)
     (hanging-indent . 3)
     (justification . full)
@@ -101,8 +100,7 @@
 		(techreport . (author title institution year))
 		(mastersthesis . (author title school year))
 		(phdthesis . (author title school year))
-		(t . (author title year)))))
-  "Unsorted bibliography style.")
+		(t . (author title year))))))
 
 (provide 'unsrt)
 

--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -61,8 +61,6 @@
 (require 's)
 
 ;;; Code:
-(defvar-local bibliography-style nil)
-
 (add-to-list 'load-path
 	     (expand-file-name
 	      "citeproc"

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -31,8 +31,6 @@
 ;;
 
 ;;; Code:
-(defvar-local bibliography-style nil)
-
 (require 'org-ref-helm)
 (require 'org-ref-bibtex)
 
@@ -53,17 +51,6 @@
     org-ref-insert-link-function))
 
 (org-ref-helm-cite-completion)
-
-(add-to-list 'load-path
-	     (expand-file-name
-	      "citeproc"
-	      (file-name-directory  (locate-library "org-ref"))))
-
-(load-file (expand-file-name
-	    "org-ref-citeproc.el"
-	    (expand-file-name
-	     "citeproc"
-	     (file-name-directory  (locate-library "org-ref")))))
 
 ;;* Variables
 (defvar org-ref-helm-cite-from nil
@@ -527,41 +514,6 @@ little more readable.")
 
 
 ;;* Formatted citations
-
-(defun orhc-formatted-citation (entry)
-  "Get a formatted string for entry."
-  (let* ((adaptive-fill-function '(lambda () "    "))
-	 (indent-tabs-mode nil)
-	 (entry-type (downcase
-		      (cdr (assoc "=type=" (cdr entry)))))
-	 (entry-styles (cdr (assoc 'entries bibliography-style)))
-	 (entry-fields
-	  (progn
-	    (if (cdr (assoc (intern entry-type) entry-styles))
-		(cdr (assoc (intern entry-type) entry-styles))
-	      (warn "%s not found. Using default." entry-type)
-	      (cdr (assoc 't entry-styles)))))
-	 (funcs (mapcar
-		 (lambda (field)
-		   (if (fboundp (intern
-				 (format "orcp-%s" field)))
-		       (intern
-			(format "orcp-%s" field))
-		     ;; No formatter found. just get the data
-		     `(lambda (entry)
-			(orcp-get-entry-field
-			 ,(symbol-name field) entry))))
-		 entry-fields)))
-
-    ;; this is the entry. We do this in a buffer to make it
-    ;; easy to indent, fill, etc...
-    (with-temp-buffer
-      (insert (mapconcat (lambda (field-func)
-			   (funcall field-func entry))
-			 funcs
-			 ""))
-      (buffer-string))))
-
 
 (defun orhc-formatted-citations (_candidate)
   "Return string containing formatted citations for entries in

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -433,7 +433,7 @@ Create email unless called from an email."
 	    (setq entry-keywords (bibtex-autokey-get-field "keywords"))
 	    (bibtex-set-field
 	     "keywords"
-	     (if entry-keywords
+	     (if (> (length entry-keywords) 0)
 		 (concat entry-keywords ", " keywords)
 	       keywords))))))
 

--- a/org-ref-ivy-bibtex.el
+++ b/org-ref-ivy-bibtex.el
@@ -169,6 +169,28 @@ Create email unless called from an email."
     (message-goto-to)))
 
 
+(defun or-ivy-bibtex-formatted-citation (entry)
+  "Return string containing formatted citations for ENTRY."
+  (let ((enable-recursive-minibuffers t))
+    (ivy-read "Style: " '("unsrt" "author-year")
+	      :action 'load-library
+	      :require-match t
+	      :preselect "unsrt"
+	      :caller 'or-ivy-formatted-citation)
+    (format "%s\n\n" (orhc-formatted-citation entry))))
+
+
+(defun or-ivy-bibtex-insert-formatted-citation (entry)
+  "Insert formatted citations at point for selected ENTRY."
+  (with-ivy-window
+    (insert (or-ivy-bibtex-formatted-citation entry))))
+
+
+(defun or-ivy-bibtex-copy-formatted-citation (entry)
+  "Copy formatted citation to clipboard for ENTRY."
+  (kill-new (or-ivy-bibtex-formatted-citation entry)))
+
+
 (defvar org-ref-ivy-cite-re-builder 'ivy--regex-ignore-order
   "Regex builder to use in `org-ref-ivy-insert-cite-link'. Can be set to nil to use Ivy's default).")
 
@@ -190,6 +212,8 @@ Create email unless called from an email."
 		      ("d" or-ivy-bibtex-open-doi "Open doi")
 		      ("k" or-ivy-bibtex-set-keywords "Add keywords")
 		      ("e" or-ivy-bibtex-email-entry "Email entry")
+		      ("f" or-ivy-bibtex-insert-formatted-citation "Insert formatted citation")
+		      ("F" or-ivy-bibtex-copy-formatted-citation "Copy formatted citation")
 		      ("q" nil "quit"))))
 
 

--- a/org-ref-ivy-bibtex.el
+++ b/org-ref-ivy-bibtex.el
@@ -191,6 +191,19 @@ Create email unless called from an email."
   (kill-new (or-ivy-bibtex-formatted-citation entry)))
 
 
+(defvar org-ref-ivy-cite-actions
+  '(("b" or-ivy-bibtex-open-entry "Open bibtex entry")
+    ("B" or-ivy-bibtex-copy-entry "Copy bibtex entry")
+    ("p" or-ivy-bibtex-open-pdf "Open pdf")
+    ("n" or-ivy-bibtex-open-notes "Open notes")
+    ("u" or-ivy-bibtex-open-url "Open url")
+    ("d" or-ivy-bibtex-open-doi "Open doi")
+    ("k" or-ivy-bibtex-set-keywords "Add keywords")
+    ("e" or-ivy-bibtex-email-entry "Email entry")
+    ("f" or-ivy-bibtex-insert-formatted-citation "Insert formatted citation")
+    ("F" or-ivy-bibtex-copy-formatted-citation "Copy formatted citation"))
+  "List of additional actions for `org-ref-ivy-insert-cite-link' (the default action being to insert a citation).")
+
 (defvar org-ref-ivy-cite-re-builder 'ivy--regex-ignore-order
   "Regex builder to use in `org-ref-ivy-insert-cite-link'. Can be set to nil to use Ivy's default).")
 
@@ -202,21 +215,14 @@ Create email unless called from an email."
   (ivy-read "Open: " (orhc-bibtex-candidates)
 	    :require-match t
 	    :re-builder org-ref-ivy-cite-re-builder
-	    :action '(1
-		      ("i" or-ivy-bibtex-insert-cite "Insert citation")
-		      ("o" or-ivy-bibtex-open-entry "Open entry")
-		      ("c" or-ivy-bibtex-copy-entry "Copy entry")
-		      ("p" or-ivy-bibtex-open-pdf "Open pdf")
-		      ("n" or-ivy-bibtex-open-notes "Open notes")
-		      ("u" or-ivy-bibtex-open-url "Open url")
-		      ("d" or-ivy-bibtex-open-doi "Open doi")
-		      ("k" or-ivy-bibtex-set-keywords "Add keywords")
-		      ("e" or-ivy-bibtex-email-entry "Email entry")
-		      ("f" or-ivy-bibtex-insert-formatted-citation "Insert formatted citation")
-		      ("F" or-ivy-bibtex-copy-formatted-citation "Copy formatted citation")
-		      ("q" nil "quit"))))
+	    :action 'or-ivy-bibtex-insert-cite
+	    :caller 'org-ref-ivy-insert-cite-link))
 
+(ivy-set-actions
+ 'org-ref-ivy-insert-cite-link
+ org-ref-ivy-cite-actions)
 
+     
 
 (defun org-ref-ivy-insert-label-link ()
   "Insert a label with ivy."


### PR DESCRIPTION
I splitted this into 5 separate commits so you can decide which ones you want (if any):

1. Add some actions to `org-ref-ivy-insert-cite-link` (open notes, url, doi, set keywords, email). I adapted the corresponding functions in `org-ref-helm-cite`. Along the way I noticed a small issue with `org-ref-helm-cite-set-keywords`, for which I propose a fix in the fourth commit.

2. Add more actions (insert / copy formatted citation). To reuse the function `orhc-formatted-citation` I moved it from `org-ref-helm-cite` to `org-ref-bibtex`, together with the code loading the `citeproc` directory. I don't see a problem with this, since `org-ref-helm-cite` calls `org-ref-bibtex` anyway, but maybe you do. Along the way I noticed that inserting formatted citations was not working for me with `org-ref-helm-cite`, and I propose a fix for this in the third commit.

3. Fix for the formatted citation issue. With this fix inserting formatted citations works for me both with `org-ref-helm-cite` and `org-ref-ivy-bibtex`, but again I am not sure that my solution is good.

4. Fix for the keywords issue.

5. Make the `org-ref-ivy-insert-cite-link` actions customizable.

Please let me know if you would like me to submit another PR with more (or less) changes, or if I can do anything else.

Thanks