### PR TITLE
add & fix PDF download support for ACM and IEEE

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -404,6 +404,18 @@ REDIRECT-URL is where the pdf url will be in."
       (when (re-search-forward "<meta name=\"citation_pdf_url\" content=\"\\([[:ascii:]]*?\\)\">")
 	(match-string 1)))))
 
+;; ACM Digital Library
+;; http://dl.acm.org/citation.cfm?doid=1368088.1368132
+;; <a name="FullTextPDF" title="FullText PDF" href="ft_gateway.cfm?id=1368132&ftid=518423&dwn=1&CFID=766519780&CFTOKEN=49739320" target="_blank">
+(defun acm-pdf-url (*doi-utils-redirect*)
+  "Get a url to the pdf from *DOI-UTILS-REDIRECT* for ACM urls."
+  (when (string-match "^http://dl.acm.org" *doi-utils-redirect*)
+    (with-current-buffer (url-retrieve-synchronously *doi-utils-redirect*)
+          (goto-char (point-min))
+          (when (re-search-forward "<a name=\"FullTextPDF\".*href=\"\\([[:ascii:]]*?\\)\"")
+            (concat "http://dl.acm.org/" (match-string 1))))))
+
+
 ;;** Add all functions
 
 (setq doi-utils-pdf-url-functions
@@ -429,6 +441,7 @@ REDIRECT-URL is where the pdf url will be in."
        'sage-pdf-url
        'jneurosci-pdf-url
        'ieee-pdf-url
+       'acm-pdf-url
        'generic-full-pdf-url))
 
 ;;** Get the pdf url for a doi

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -396,13 +396,18 @@ REDIRECT-URL is where the pdf url will be in."
 ;; http://ieeexplore.ieee.org/ielx7/6903646/6912234/06912247.pdf
 ;; http://ieeexplore.ieee.org/iel7/6903646/6912234/06912247.pdf?arnumber=6912247
 ;; <meta name="citation_pdf_url" content="http://ieeexplore.ieee.org/iel7/6903646/6912234/06912247.pdf?arnumber=6912247">
+;; <frame src="http://ieeexplore.ieee.org/ielx7/6903646/6912234/06912247.pdf?tp=&arnumber=6912247&isnumber=6912234" frameborder=0 />
 (defun ieee-pdf-url (*doi-utils-redirect*)
   "Get a url to the pdf from *DOI-UTILS-REDIRECT* for IEEE urls."
   (when (string-match "^http://ieeexplore.ieee.org" *doi-utils-redirect*)
     (with-current-buffer (url-retrieve-synchronously *doi-utils-redirect*)
       (goto-char (point-min))
       (when (re-search-forward "<meta name=\"citation_pdf_url\" content=\"\\([[:ascii:]]*?\\)\">")
-	(match-string 1)))))
+	(let ((framed-url (match-string 1)))
+          (with-current-buffer (url-retrieve-synchronously framed-url)
+            (goto-char (point-min))
+            (when (re-search-forward "<frame src=\"\\(http[[:ascii:]]*?\\)\"")
+              (match-string 1))))))))
 
 ;; ACM Digital Library
 ;; http://dl.acm.org/citation.cfm?doid=1368088.1368132


### PR DESCRIPTION
I just figured out the issue #169.

First, I added the ACM Digital Library support by mimicking the IEEE one.

The current `ieee-pdf-url` function is also not working, due that IEEEXplore adds its frame to the pdf page. Thus another url request and parsing is needed to extract the true pdf link without the frame.

This two functionalities are both tested and working. The appropriate comments for the actual html tags for both ACM and IEEE are added.