### PR TITLE
Ivy

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -976,7 +976,7 @@ This generates the candidates for the file. Some of this code is
 adapted from `helm-bibtex-parse-bibliography'. This function runs
 when called, it resets the cache for the BIBFILE."
   (with-current-buffer (find-file-noselect bibfile)
-    (goto-char (point-min))
+    (bibtex-beginning-of-first-entry)
     (message "Updating cache for %s" bibfile)
     (let ((hash (secure-hash 'sha256 (current-buffer)))
 	  (entries

--- a/org-ref-ivy-bibtex.el
+++ b/org-ref-ivy-bibtex.el
@@ -189,7 +189,7 @@ Create email unless called from an email."
 (defun or-ivy-bibtex-copy-formatted-citation (entry)
   "Copy formatted citation to clipboard for ENTRY."
   (kill-new (or-ivy-bibtex-formatted-citation entry)))
-g
+
 
 (defun or-ivy-bibtex-add-entry (entry)
   "Open a bibliography file and move point to the end, in order to add a new bibtex entry. ENTRY is selected from `orhc-bibtex-candidates' but ignored."

--- a/org-ref-ivy-bibtex.el
+++ b/org-ref-ivy-bibtex.el
@@ -189,6 +189,18 @@ Create email unless called from an email."
 (defun or-ivy-bibtex-copy-formatted-citation (entry)
   "Copy formatted citation to clipboard for ENTRY."
   (kill-new (or-ivy-bibtex-formatted-citation entry)))
+g
+
+(defun or-ivy-bibtex-add-entry (entry)
+  "Open a bibliography file and move point to the end, in order to add a new bibtex entry. ENTRY is selected from `orhc-bibtex-candidates' but ignored."
+  (ivy-read "bibtex file: " org-ref-bibtex-files
+	    :require-match t
+	    :action 'find-file
+	    :caller 'or-ivy-bibtex-add-entry)
+  (widen)
+  (goto-char (point-max))
+  (unless (bolp)
+    (insert "\n")))
 
 
 (defvar org-ref-ivy-cite-actions
@@ -201,17 +213,20 @@ Create email unless called from an email."
     ("k" or-ivy-bibtex-set-keywords "Add keywords")
     ("e" or-ivy-bibtex-email-entry "Email entry")
     ("f" or-ivy-bibtex-insert-formatted-citation "Insert formatted citation")
-    ("F" or-ivy-bibtex-copy-formatted-citation "Copy formatted citation"))
+    ("F" or-ivy-bibtex-copy-formatted-citation "Copy formatted citation")
+    ("a" or-ivy-bibtex-add-entry "Add bibtex entry"))
   "List of additional actions for `org-ref-ivy-insert-cite-link' (the default action being to insert a citation).")
 
 (defvar org-ref-ivy-cite-re-builder 'ivy--regex-ignore-order
   "Regex builder to use in `org-ref-ivy-insert-cite-link'. Can be set to nil to use Ivy's default).")
 
 
-(defun org-ref-ivy-insert-cite-link ()
+(defun org-ref-ivy-insert-cite-link (&optional arg)
   "ivy function for interacting with bibtex."
-  (interactive)
-  (setq org-ref-bibtex-files (org-ref-find-bibliography))
+  (interactive "P")
+  (setq org-ref-bibtex-files (if arg
+				 org-ref-default-bibliography
+			       (org-ref-find-bibliography)))
   (ivy-read "Open: " (orhc-bibtex-candidates)
 	    :require-match t
 	    :re-builder org-ref-ivy-cite-re-builder


### PR DESCRIPTION
- New option: when called with a prefix argument, `org-ref-ivy-insert-cite-link` systematically uses `org-ref-default-bibliography` and not `org-ref-find-bibliography`. This makes it possible to access the default bibliography even from documents that specify a different bibliography.

- New action in `org-ref-ivy-insert-cite-link` to add a new bibtex entry. This simply opens the bib file and moves point to the end (from there an entry can be added manually or using `doi-utils'). Combined   with the previous option, this makes it possible to copy/paste entries between the default bibliography and document-specific bibliographies.

- In `orhc-update-bibtex-cache`, replaced `(goto-char (point-min))` with
`(bibtex-beginning-of-first-entry)`. Without this change, `parsebib`
generates an error when the bibtex file starts with a comment.