### PR TITLE
org-ref.el: require f and s

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -37,6 +37,8 @@
 (eval-when-compile
   (require 'cl))
 (require 'dash)
+(require 'f)
+(require 's)
 (require 'doi-utils)
 (require 'org-ref-bibtex)
 (require 'org-ref-utils)


### PR DESCRIPTION
I think in the past this was not needed because org-ref.el was requiring
helm-bibtex which in turn required f and s.