### PR TITLE
locate bibliography files in bibtex path

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -1603,18 +1603,6 @@ set in `org-ref-default-bibliography'"
       (when org-ref-bibliography-files
 	(throw 'result org-ref-bibliography-files))))
 
-    ;; Try BIBINPUTS.
-    (setq org-ref-bibliography-files
-	  (apply
-	   'append
-	   (loop for path in (reftex-access-search-path "bib" t default-directory)
-		 when (file-exists-p path)
-		 collect
-		 (-filter (lambda (f) (f-ext? f "bib"))
-			  (f-files path)))))
-    (when org-ref-bibliography-files
-      (throw 'result org-ref-bibliography-files))
-
     ;; we did not find anything. use defaults
     (setq org-ref-bibliography-files org-ref-default-bibliography))
 

--- a/org-ref.el
+++ b/org-ref.el
@@ -1574,61 +1574,49 @@ set in `org-ref-default-bibliography'"
     (when (string= (or (f-ext (or (buffer-file-name) "")) "")  "bib")
       (setq org-ref-bibliography-files (list (buffer-file-name)))
       (throw 'result org-ref-bibliography-files))
+
     ;; otherwise, check current file for a bibliography source
     (save-excursion (save-restriction
       (widen)                
       (goto-char (point-min))
-      ;;  look for a bibliography link
-      (when (re-search-forward "\\<bibliography:\\([^\]\|\n]+\\)" nil t)
+
+      ;; look for org-ref bibliography or addbibresource links
+      (setq org-ref-bibliography-files nil)
+      (while (re-search-forward
+	      "\\<\\(bibliography\\|addbibresource\\):\\([^\]\|\n]+\\)"
+	      nil t)
         (setq org-ref-bibliography-files
-              (mapcar 'org-ref-strip-string
-		      (split-string (match-string 1) ",")))
-        (throw 'result org-ref-bibliography-files))
-
-
-      ;; we did not find a bibliography link. now look for \bibliography
-      (goto-char (point-min))
-      (when (re-search-forward "\\\\bibliography{\\(.*?\\)}" nil t)
-        ;; split, and add .bib to each file
-        (setq org-ref-bibliography-files
-              (mapcar (lambda (x) (concat x ".bib"))
-                      (mapcar 'org-ref-strip-string
-                              (split-string (match-string 1) ","))))
-        (throw 'result org-ref-bibliography-files))
-
-      ;; no bibliography found. maybe we need a biblatex addbibresource
-      (goto-char (point-min))
-      ;;  look for a bibliography link
-      (when (re-search-forward "addbibresource:\\([^\]\|\n]+\\)" nil t)
-        (setq org-ref-bibliography-files
-              (mapcar 'org-ref-strip-string
-		      (split-string (match-string 1) ",")))
-        (throw 'result org-ref-bibliography-files))
-
-      ;; one last attempt at the latex addbibresource
-      (goto-char (point-min))
-      (when (re-search-forward "\\addbibresource{\\(.*?\\)}" nil t)
-	(setq org-ref-bibliography-files
-	      (mapcar 'org-ref-strip-string
-		      (split-string (match-string 1) ",")))
+	      (append org-ref-bibliography-files
+		      (mapcar 'org-ref-strip-string
+			      (split-string (match-string 2) ",")))))
+      ;; locate the corresponding bib files
+      (setq org-ref-bibliography-files
+	    (reftex-locate-bibliography-files default-directory
+					      org-ref-bibliography-files))
+      (when org-ref-bibliography-files
 	(throw 'result org-ref-bibliography-files))
 
-      ;; Try BIBINPUTS. It is a : separated string of paths.
-      (let ((bibinputs (getenv "BIBINPUTS")))
-	(when bibinputs
-	  (setq org-ref-bibliography-files
-		(apply
-		 'append
-		 (loop for path in (split-string  bibinputs ":")
-		       collect
-		       (-filter (lambda (f) (f-ext? f "bib"))
-				(f-files
-				 (substitute-in-file-name  path))))))
-	  (when org-ref-bibliography-files
-	    (throw 'result org-ref-bibliography-files))))
+      ;; we did not find org-ref links. now look for latex links
+      (goto-char (point-min))
+      (setq org-ref-bibliography-files
+	    (reftex-locate-bibliography-files default-directory))
+      (when org-ref-bibliography-files
+	(throw 'result org-ref-bibliography-files))))
 
-      ;; we did not find anything. use defaults
-      (setq org-ref-bibliography-files org-ref-default-bibliography))))
+    ;; Try BIBINPUTS.
+    (setq org-ref-bibliography-files
+	  (apply
+	   'append
+	   (loop for path in (reftex-access-search-path "bib" t default-directory)
+		 when (file-exists-p path)
+		 collect
+		 (-filter (lambda (f) (f-ext? f "bib"))
+			  (f-files path)))))
+    (when org-ref-bibliography-files
+      (throw 'result org-ref-bibliography-files))
+
+    ;; we did not find anything. use defaults
+    (setq org-ref-bibliography-files org-ref-default-bibliography))
 
   ;; set reftex-default-bibliography so we can search
   (set (make-local-variable 'reftex-default-bibliography) org-ref-bibliography-files)


### PR DESCRIPTION
It seems to me that there is some discrepancy between the way `org-ref` locates bibliography files and the way `latex` does. For instance, if I have a default bibliography file `default.bib` somewhere in my `BIBINPUTS` path, then I can simply write `\bibliography{default} in my `latex` file and it will be found. On the other hand, if I write `bibliography:default.bib` in my `org` file, `org-ref` will simply expand `default.bib` from the current directory and therefore won't find the file.

So the first commit in this PR modifies `org-ref-find-bibliography` to behave more naturally (in my opinion). It simply uses `reftex` funcitons to locate the files collected from the bibliography links in the bibtex path. It also collects the bibliography files from all the bibliography and/or addibibresource links, not only the first one (this better supports biblatex which allows for multiple such commands).

The second commit then removes the "Try BIBINPUT" step. I did this in a separate commit so you can reject it if you disagree with me, but I think that if there is no bibligoraphy link it is better to use `org-ref-default-bibliography` directly rather than collecting all the bibtex files in BIBINPUTS (there may be files there that are not intended as default bibliographies).

Please let me know if you would like me to change / test anything.