### PR TITLE
Modification org-ref-open-bibtex-notes function

### DIFF
--- a/org-ref.el
+++ b/org-ref.el
@@ -2054,10 +2054,11 @@ construct the heading by hand."
 	  (setq pdf (-first 'f-file?
 			    (--map (f-join it (concat key ".pdf"))
 				   (-flatten (list org-ref-pdf-directory)))))
+	  (setq pdfrel (format "%s" key))	
 	  (if (file-exists-p pdf)
 	      (insert (format
-		       " [[file:%s][pdf]]\n\n"
-		       pdf))
+		       " [[papers:%s][pdf]]\n\n"
+		       pdfrel))
 	    ;; no pdf found. Prompt for a path, but allow no pdf to be inserted.
 	    (let ((pdf (read-file-name "PDF: " nil "no pdf" nil "no pdf")))
 	      (when (not (string= pdf "no pdf"))


### PR DESCRIPTION
Under the current setup, a new note in the org notes file is created according the user defined format, plus a line like:
[[cite:key]] [[pdf-path][pdf]]

Unfortunately the pdf-path is set to be absolute, so this does not work if you have several systems, for instance using org-ref on dropbox on a home and office system. I have modified the org-ref-open-bibtex notes function so the link is inserted as:
[[papers:key][pdf]]

Where papers is an org abbreviation set locally:
(setq org-link-abbrev-alist '(("papers" . "~/path/to/pdfs/%s.pdf")))

This allows org-ref to work across several systems.