### PR TITLE
show existing keywords in the minibuffer

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -172,17 +172,24 @@ Argument CANDIDATES helm candidates."
 	     do
 	     (save-window-excursion
 	       (bibtex-completion-show-entry key)
-	       (bibtex-set-field
-		"keywords"
-		(concat
-	       	 (if (listp keywords)
-	       	     (if (string-match value keywords)
-	       		 (and (replace-match "")
-	       		      (mapconcat 'identity keywords ", "))
-	       	       (mapconcat 'identity keywords ", "))
-	       	   keywords)))
+	       ;; delete keyword field if empty
+	       (if (string-match "^\s-*" keywords)
+		   (save-restriction
+		     (bibtex-narrow-to-entry)
+		     (bibtex-beginning-of-entry)
+		     (goto-char (car (cdr (bibtex-search-forward-field "keywords" t))))
+		     (bibtex-kill-field))
+		 (bibtex-set-field
+		  "keywords"
+		  (concat
+		   (if (listp keywords)
+		       (if (string-match value keywords)
+			   (and (replace-match "")
+				(mapconcat 'identity keywords ", "))
+			 (mapconcat 'identity keywords ", "))
+		     keywords))))
 	       (when (looking-back ", ")
-		 (delete-backward-char 2))
+	       	 (delete-backward-char 2))
 	       (save-buffer)))))
 
 

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -167,7 +167,7 @@ Argument CANDIDATES helm candidates."
 	 (entry (bibtex-completion-get-entry (car keys)))
 	 (field (cdr (assoc-string "keywords" entry)))
 	 (value (when field (replace-regexp-in-string "^{\\|}$" "" field)))
-	 (keywords (read-string "Keywords (comma separated): " value)))
+	 (keywords (read-string "Keywords (comma separated): " (concat value ", "))))
     (cl-loop for key in keys
 	     do
 	     (save-window-excursion

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -176,7 +176,6 @@ Argument CANDIDATES helm candidates."
 	       (if (string-match "^\s-*" keywords)
 		   (save-restriction
 		     (bibtex-narrow-to-entry)
-		     (bibtex-beginning-of-entry)
 		     (goto-char (car (cdr (bibtex-search-forward-field "keywords" t))))
 		     (bibtex-kill-field))
 		 (bibtex-set-field

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -163,18 +163,26 @@ CANDIDATE is ignored."
 User is prompted for tags.  This function is called from `helm-bibtex'.
 Argument CANDIDATES helm candidates."
   (message "")
-  (let ((keywords (read-string "Keywords (comma separated): ")))
-    (cl-loop for key in (helm-marked-candidates)
-             do
-             (save-window-excursion
-               (bibtex-completion-show-entry key)
-               (bibtex-set-field
-                "keywords"
-                (concat
-                 keywords
-                 ", " (bibtex-autokey-get-field "keywords")))
+  (let* ((keys (helm-marked-candidates))
+	 (entry (bibtex-completion-get-entry (car keys)))
+	 (field (cdr (assoc-string "keywords" entry)))
+	 (value (when field (replace-regexp-in-string "^{\\|}$" "" field)))
+	 (keywords (read-string "Keywords (comma separated): " value)))
+    (cl-loop for key in keys
+	     do
+	     (save-window-excursion
+	       (bibtex-completion-show-entry key)
+	       (bibtex-set-field
+		"keywords"
+		(concat
+	       	 (if (listp keywords)
+	       	     (if (string-match value keywords)
+	       		 (and (replace-match "")
+	       		      (mapconcat 'identity keywords ", "))
+	       	       (mapconcat 'identity keywords ", "))
+	       	   keywords)))
 	       (when (looking-back ", ")
-	       	 (delete-backward-char 2))
+		 (delete-backward-char 2))
 	       (save-buffer)))))
 
 


### PR DESCRIPTION
This will use existing keywords as the initial input, which is useful
for deleting, renaming and sorting keywords.