### PR TITLE
Load org-ref-core from backends

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -182,11 +182,6 @@ that was clicked on."
   :type 'function
   :group 'org-ref)
 
-;; now load the completion library.
-;; (message-box "Requiring %s" org-ref-completion-library)
-;; (load-file (format "%s.el" ))
-(require org-ref-completion-library)
-
 ;; define key for inserting citations
 (define-key org-mode-map
   (kbd org-ref-insert-cite-key)

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -51,14 +51,7 @@
 	org-ref-insert-cite-function 'org-ref-helm-insert-cite-link
 	org-ref-insert-label-function 'org-ref-helm-insert-label-link
 	org-ref-insert-ref-function 'org-ref-helm-insert-ref-link
-	org-ref-cite-onclick-function 'org-ref-cite-click-helm)
-
-  ;; define key for inserting citations
-  (define-key org-mode-map
-    (kbd org-ref-insert-cite-key)
-    org-ref-insert-link-function))
-
-(org-ref-bibtex-completion-completion)
+	org-ref-cite-onclick-function 'org-ref-cite-click-helm))
 
 (defcustom org-ref-bibtex-completion-actions
   '(("Insert citation" . helm-bibtex-insert-citation)

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -58,14 +58,7 @@
 	org-ref-insert-cite-function 'org-ref-helm-cite
 	org-ref-insert-label-function 'org-ref-helm-insert-label-link
 	org-ref-insert-ref-function 'org-ref-helm-insert-ref-link
-	org-ref-cite-onclick-function 'org-ref-cite-click-helm)
-
-  ;; define key for inserting citations
-  (define-key org-mode-map
-    (kbd org-ref-insert-cite-key)
-    org-ref-insert-link-function))
-
-(org-ref-helm-cite-completion)
+	org-ref-cite-onclick-function 'org-ref-cite-click-helm))
 
 ;;* Variables
 (defvar org-ref-helm-cite-from nil

--- a/org-ref-helm.el
+++ b/org-ref-helm.el
@@ -32,6 +32,7 @@
 (declare-function 'org-ref-bad-label-candidates "org-ref-core.el")
 
 (require 'org-element)
+(require 'org-ref-core)
 
 ;;;###autoload
 (defun org-ref-helm-insert-label-link ()

--- a/org-ref-ivy-cite.el
+++ b/org-ref-ivy-cite.el
@@ -30,6 +30,7 @@
 
 ;;; Code:
 (require 'ivy)
+(require 'org-ref-core)
 (require 'org-ref-bibtex)
 (require 'org-ref-citeproc)
 
@@ -48,15 +49,7 @@
 	org-ref-insert-cite-function 'org-ref-ivy-insert-cite-link
 	org-ref-insert-label-function 'org-ref-ivy-insert-label-link
 	org-ref-insert-ref-function 'org-ref-ivy-insert-ref-link
-	org-ref-cite-onclick-function (lambda (_) (org-ref-cite-hydra/body)))
-
-  ;; define key for inserting citations
-  (define-key org-mode-map
-    (kbd org-ref-insert-cite-key)
-    org-ref-insert-link-function))
-
-;; setup the functions and keybinding
-(org-ref-ivy-cite-completion)
+	org-ref-cite-onclick-function (lambda (_) (org-ref-cite-hydra/body))))
 
 ;; messages in minibuffer interfere with hydra menus.
 (setq org-ref-show-citation-on-enter nil)

--- a/org-ref-ivy.el
+++ b/org-ref-ivy.el
@@ -26,10 +26,7 @@
 
 ;;; Commentary:
 
-
-(setq org-ref-completion-library 'org-ref-ivy-cite)
-
-(require 'org-ref-ivy-cite)
+(org-ref-ivy-cite-completion)
 
 (provide 'org-ref-ivy)
 

--- a/org-ref-reftex.el
+++ b/org-ref-reftex.el
@@ -26,6 +26,7 @@
 ;;; Code:
 (require 'reftex)
 (require 'reftex-cite)
+(require 'org-ref-core)
 (require 'org-ref-utils)
 
 (declare-function 'org-ref-find-bibliography "org-ref-core.el")
@@ -47,14 +48,7 @@
 	org-ref-insert-label-function 'org-insert-link
 	org-ref-insert-ref-function 'org-insert-link
 	org-ref-cite-onclick-function 'org-ref-cite-onclick-minibuffer-menu)
-
-  ;; define key for inserting citations
-  (define-key org-mode-map
-    (kbd org-ref-insert-cite-key)
-    org-ref-insert-link-function)
   (message "reftex completion in org-ref loaded."))
-
-(org-ref-reftex-completion)
 
 ;; Messages in the minbuffer conflict with the minibuffer menu. So we turn them
 ;; off.

--- a/org-ref.el
+++ b/org-ref.el
@@ -37,8 +37,8 @@
 ;;
 
 ;;; Code:
-(setq org-ref-completion-library 'org-ref-helm-bibtex)
-(require 'org-ref-core)
+
+(org-ref-bibtex-completion-completion)
 
 ;;* The end
 (provide 'org-ref)


### PR DESCRIPTION
Re #133 

Removed `(require org-ref-completion-library)` from `org-ref-core.el` and instead added `(require 'org-ref-core)` to `org-ref-helm.el`,  `org-ref-ivy-cite.el`, and `org-ref-reftex.el`.

Calling either one of `org-ref-bibtex-completion-completion`, `org-ref-ivy-completion`, `org-ref-helm-cite-completion`, or `org-ref-reftex-completion`, is now enough to set everything up since these files are aotuloaded. In fact `org-ref.el` now only contains `(org-ref-bibtex-completion-completion)`, so that `(require 'org-ref)` works equivalently. Similarly for `org-ref-ivy`.

I also removed the `(define-ley ...)` statements inside these four functions, since they are redundant with the same statement in `org-ref-core.el`.

I hope this makes sense, I did some testing and did not notice any problem.