### PR TITLE
Improve browsing

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -691,7 +691,14 @@ With a prefix ARG, browse labels."
 				   ;; FIXME: only works forward
 				   (goto-char
 				    (if (re-search-forward candidate nil t)
-					(point)
+					(progn
+					  ;; here we replace the value
+					  ;; of the alist with the
+					  ;; current point position.
+					  ;; This is needed when the
+					  ;; citation link repeats.
+					  (setf (cdr (assoc candidate alist)) (point))
+					  (point))
 				      nil))
 				   (backward-char 1)
 				   (helm-highlight-current-line nil nil nil nil 'pulse))

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -675,29 +675,31 @@ With a prefix ARG, browse labels."
 		(dolist (key
 			 (org-ref-split-and-strip-string (plist-get plist ':path)))
 		  (setq keys (append keys (list key)))
-		  (setq alist (append alist (list (cons key start)))) ))))))
-      (helm :sources
-	    (helm-build-sync-source "Browse citation links"
-	      :follow 1
-	      :candidates (mapcar (lambda (key)
-				    (format "%s" key))
-				  keys)
-	      :candidate-transformer 'org-ref-propertize-link-candidates
-	      :persistent-action (lambda (candidate)
-				   ;; FIXME: only works forward
-				   (goto-char
-				    (if (re-search-forward candidate nil t)
-					(point)
-				      nil))
-				   (backward-char 1)
-				   (helm-highlight-current-line nil nil nil nil 'pulse))
-	      :action `(("Open menu" . ,(lambda (candidate)
-					  (save-excursion
-					    (goto-char
-					     (cdr (assoc candidate alist)))
-					    (org-open-at-point))))
-			("Browse links" . org-ref-browse-citation-links)))
-	    :buffer "*helm browser*"))))
+		  (setq alist (append alist (list (cons key start))))))))))
+      (save-excursion
+	(goto-char (point-min))
+	(helm :sources
+	      (helm-build-sync-source "Browse citation links"
+		:follow 1
+		:candidates (mapcar (lambda (key)
+				      (format "%s" key))
+				    keys)
+		:candidate-transformer 'org-ref-propertize-link-candidates
+		:persistent-action (lambda (candidate)
+				     ;; FIXME: only works forward
+				     (goto-char
+				      (if (re-search-forward candidate nil t)
+					  (point)
+					nil))
+				     (backward-char 1)
+				     (helm-highlight-current-line nil nil nil nil 'pulse))
+		:action `(("Open menu" . ,(lambda (candidate)
+					    (save-excursion
+					      (goto-char
+					       (cdr (assoc candidate alist)))
+					      (org-open-at-point))))
+			  ("Browse links" . org-ref-browse-citation-links)))
+	      :buffer "*helm browser*")))))
 
 (provide 'org-ref-helm-bibtex)
 ;;; org-ref-helm-bibtex.el ends here

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -588,9 +588,14 @@ KEY is returned for the selected item(s) in helm."
 ;; browse citation links
 
 (defun org-ref-browser-transformer (candidates)
+  "Add counter to candidates."
   (let ((counter 0))
     (cl-loop for i in candidates
 	     collect (format "%s %s" (cl-incf counter) i))))
+
+(defun org-ref-browser-display (candidate)
+  "Strip counter from candidates."
+  (replace-regexp-in-string "^[0-9]+? " "" candidate))
 
 ;;;###autoload
 (defun org-ref-browser (&optional arg)
@@ -614,13 +619,13 @@ With a prefix ARG, browse labels."
 		  (setq keys (append keys (list key)))
 		  (setq alist (append alist (list (cons key start))))))))))
       (let ((counter 0))
-	;; the idea here is to create an alist with ("counter key" .
-	;; position) to produce unique candidates
-	(setq count-key-pos (list
-			     (mapcar (lambda (x)
-				       (cons
-					(format "%s %s" (cl-incf counter) (car x)) (cdr x)))
-				     alist))))
+      	;; the idea here is to create an alist with ("counter key" .
+      	;; position) to produce unique candidates
+      	(setq count-key-pos (list
+      			     (mapcar (lambda (x)
+      				       (cons
+      					(format "%s %s" (cl-incf counter) (car x)) (cdr x)))
+      				     alist))))
       ;; push mark to restore position with C-u C-SPC
       (push-mark (point))
       ;; move point to the first citation link in the buffer
@@ -630,14 +635,15 @@ With a prefix ARG, browse labels."
 	      :follow 1
 	      :candidates keys
 	      :candidate-transformer 'org-ref-browser-transformer
+	      :real-to-display 'org-ref-browser-display
 	      :persistent-action (lambda (candidate)
-				   (goto-char
-				    (cdr (assoc candidate (car count-key-pos))))
-				   (helm-highlight-current-line nil nil nil nil 'pulse))
+	      			   (helm-goto-char
+	      			    (cdr (assoc candidate (car count-key-pos))))
+	      			   (helm-highlight-current-line nil nil nil nil 'pulse))
 	      :action `(("Open menu" . ,(lambda (candidate)
-					  (goto-char
-					   (cdr (assoc candidate (car count-key-pos))))
-					  (org-open-at-point)))))
+	      				  (helm-goto-char
+	      				   (cdr (assoc candidate (car count-key-pos))))
+	      				  (org-open-at-point)))))
 	    :candidate-number-limit 10000
 	    :buffer "*helm browser*"))))
 

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -621,11 +621,10 @@ With a prefix ARG, browse labels."
       (let ((counter 0))
       	;; the idea here is to create an alist with ("counter key" .
       	;; position) to produce unique candidates
-      	(setq count-key-pos (list
-      			     (mapcar (lambda (x)
-      				       (cons
-      					(format "%s %s" (cl-incf counter) (car x)) (cdr x)))
-      				     alist))))
+      	(setq count-key-pos (mapcar (lambda (x)
+				      (cons
+				       (format "%s %s" (cl-incf counter) (car x)) (cdr x)))
+				    alist)))
       ;; push mark to restore position with C-u C-SPC
       (push-mark (point))
       ;; move point to the first citation link in the buffer
@@ -638,11 +637,11 @@ With a prefix ARG, browse labels."
 	      :real-to-display 'org-ref-browser-display
 	      :persistent-action (lambda (candidate)
 	      			   (helm-goto-char
-	      			    (cdr (assoc candidate (car count-key-pos))))
+	      			    (cdr (assoc candidate count-key-pos)))
 	      			   (helm-highlight-current-line nil nil nil nil 'pulse))
 	      :action `(("Open menu" . ,(lambda (candidate)
 	      				  (helm-goto-char
-	      				   (cdr (assoc candidate (car count-key-pos))))
+	      				   (cdr (assoc candidate count-key-pos)))
 	      				  (org-open-at-point)))))
 	    :candidate-number-limit 10000
 	    :buffer "*helm browser*"))))

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -679,7 +679,8 @@ With a prefix ARG, browse labels."
 		  (setq alist (append alist (list (cons key start))))))))))
       ;; push mark to restore our position later with C-u C-SPC
       (push-mark (point))
-      (goto-char (point-min))
+      ;; move point to the first link in the buffer
+      (goto-char (cdr (assoc (caar alist) alist)))
       (helm :sources
 	    (helm-build-sync-source "Browse citation links"
 	      :follow 1
@@ -705,6 +706,9 @@ With a prefix ARG, browse labels."
 	      :action `(("Open menu" . ,(lambda (candidate)
 					  (goto-char
 					   (cdr (assoc candidate alist)))
+					  ;; don't move the point on the first link
+					  (unless (eq (point) (cdr (assoc (caar alist) alist)))
+					    (backward-char 1))
 					  (org-open-at-point)))
 			("Browse links" . org-ref-browse-citation-links)))
 	    :buffer "*helm browser*"))))


### PR DESCRIPTION
- This uses all citation links as candidates
- Press C-n (or type) to navigate
- Press RET to open the menu
- Browse labels with a prefix argument

You need the latest helm version installed (the melpa one is fine).