### PR TITLE
added function to async load helm cite sources

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -317,26 +317,46 @@ change the key at point to the selected keys."
 
 
 ;;;###autoload
-(defun org-ref-helm-load-completion-source-async ()
+(defun org-ref-helm-load-completions-async ()
   "Load the bibtex files into helm sources asynchronously.
 For large bibtext files, the intial call to ‘org-ref-helm-insert-cite-link’
 can take a long time to load the completion sources.  This function loads
 the completion sources in the background so the initial call to ‘org-ref-helm-insert-cite-link’ is much faster."
-  (interactive)
-  (async-start
-   (lambda ()
-     (require 'package)
-     (package-initialize)
-     (require 'org-ref)
-     (async-inject-variables "bibtex-completion-bibliography")
-     (bibtex-completion-candidates))
-   (lambda (result)
-     (setq bibtex-completion-cached-candidates result)
-     (with-temp-buffer
-       (mapc #'insert-file-contents
-	     (-flatten (list bibtex-completion-bibliography)))
-       (setq bibtex-completion-bibliography-hash (secure-hash 'sha256 (current-buffer))))
-     (message "Loaded org-ref completion candidates"))))
+(interactive)
+    (async-start
+     `(lambda (&optional formatter)
+       (require 'package)
+       (package-initialize)
+       (require 'helm-bibtex)
+       ,(async-inject-variables "bibtex-compl.*")
+       ;;(setq bibtex-completion-bibliography "C:\\Users\\A6419643\\Documents\\library.bib")
+       (with-temp-buffer
+	 (mapc #'insert-file-contents
+	       (-flatten (list bibtex-completion-bibliography)))
+	 ;; Check hash of bibliography and reparse if necessary:
+	 (let ((bibliography-hash (secure-hash 'sha256 (current-buffer))))
+	   (unless (and bibtex-completion-cached-candidates
+			(string= bibtex-completion-bibliography-hash bibliography-hash))
+	     (message "Loading bibliography ...")
+	     (let* ((entries (bibtex-completion-parse-bibliography))
+		    (entries (bibtex-completion-resolve-crossrefs entries))
+		    (entries (bibtex-completion-prepare-entries entries))
+		    (entries (nreverse entries))
+		    (entries
+		     (--map (cons (bibtex-completion-clean-string
+				   (s-join " " (-map #'cdr it))) it)
+			    entries)))
+	       (setq bibtex-completion-cached-candidates
+		     (if (functionp formatter)
+			 (funcall formatter entries)
+		       entries)))
+	     (setq bibtex-completion-bibliography-hash bibliography-hash))
+	  (cons bibliography-hash bibtex-completion-cached-candidates))))
+     (lambda (result)
+       (setq bibtex-completion-cached-candidates (cdr result))
+       (setq bibtex-completion-bibliography-hash (car result))
+       (message "All Done Loading Candidates"))))
+ 
 
 
 

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -355,7 +355,7 @@ the completion sources in the background so the initial call to ‘org-ref-helm-
      (lambda (result)
        (setq bibtex-completion-cached-candidates (cdr result))
        (setq bibtex-completion-bibliography-hash (car result))
-       (message "All Done Loading Candidates"))))
+       (message "Finished loading org-ref completions"))))
  
 
 


### PR DESCRIPTION
The first time that org-ref-helm-insert-cite-link is called,
it can take a long time to load the completion sources. This
pull request creates a new function, org-ref-helm-load-completion-source-async
that will load the bibtex file into a helm source in the
background. This way, the user can continue working with their document
while helm loads their sources silently in the background.

This would also be useful in situations where you are making changes to the
bibtex file while writing. After saving the file, you could asynchronously load
it into the helm source and not have to wait for it to load during the first call
to a citation function.

This adds two dependencies to org-ref-helm-bibtex - async and package.
Using package within the async call is necessary because there are
many, many functions and packages that go into the process of building
up the helm-source list. We could try to untangle them and only load
those that are absolutely necessary, but this would not be robust to
upstream changes.