### PR TITLE
Undo Mendeley commit

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -403,7 +403,6 @@ Checks for pdf and doi, and add appropriate functions."
          (key (car results))
          (pdf-file (funcall org-ref-get-pdf-filename-function key))
 	 (pdf-bibtex-completion (car (bibtex-completion-find-pdf key)))
-	 (pdf-mendeley (org-ref-get-mendeley-filename key))
          (bibfile (cdr results))
          (url (save-excursion
                 (with-temp-buffer
@@ -436,13 +435,6 @@ Checks for pdf and doi, and add appropriate functions."
 
 	   ;; try with bibtex-completion
     	  (pdf-bibtex-completion
-    	   (cl-pushnew
-    	    '("Open pdf" . (lambda ()
-    			     (funcall org-ref-open-pdf-function)))
-    	    candidates))
-
-	  ;; try with mendeley function
-    	  ((file-exists-p pdf-mendeley)
     	   (cl-pushnew
     	    '("Open pdf" . (lambda ()
     			     (funcall org-ref-open-pdf-function)))

--- a/org-ref.org
+++ b/org-ref.org
@@ -545,7 +545,7 @@ There are a few different ways in which PDFs can be opened from org-ref. By defa
 
 *** A note for Mendeley, JabRef and Zotero users
 
-If ~bibtex-completion-pdf-field~ is defined, the function below should work with Mendeley, JabRef and Zotero. For more information, see https://github.com/tmalsburg/helm-bibtex#pdf-files.
+If ~bibtex-completion-pdf-field~ is defined, the function below should work with JabRef and Zotero. For more information, see https://github.com/tmalsburg/helm-bibtex#pdf-files.
 
 #+begin_src emacs-lisp
 (defun my/org-ref-open-pdf-at-point ()
@@ -561,7 +561,7 @@ If ~bibtex-completion-pdf-field~ is defined, the function below should work with
 (setq org-ref-open-pdf-function 'my/org-ref-open-pdf-at-point)
 #+end_src
 
-Alternatively, org-ref also provides a function specific to Mendeley users:
+Mendeley users should set to:
 
 #+BEGIN_SRC emacs-lisp
 (setq org-ref-open-pdf-function 'org-ref-get-mendeley-filename)


### PR DESCRIPTION
My last commit didn't quite solve the problem. In any case, org-ref-get-mendeley-filename seems to be working fine, so I update the manual accordingly.