### PR TITLE
Fix total width of helm-bibtex entries

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -133,7 +133,7 @@ fields, the keywords I think."
    collect
    (cons (s-format "$0 $1 $2 $3 $4$5 $6" 'elt
                    (-zip-with (lambda (f w) (truncate-string-to-width f w 0 ?\s))
-                              fields (list 36 (- width 85) 4 1 1 7 7)))
+                              fields (list 36 (- width 85) 4 1 1 7 31)))
          entry-key)))
 
 


### PR DESCRIPTION
The total number of characters in the string `"$0 $1 $2 $3 $4$5 $6"` should be equal to `width`, that is 5 spaces from the format string and the number of characters in the list. I chose to extend the field with the keywords - but maybe this should be made configurable...