### PR TITLE
Bugfix to opening url/doi at point, and support for 'pandoc export backend.

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -1775,7 +1775,7 @@ If no key is provided, get one under point."
      ,(format "Formatting function for %s links.
 [[%s:KEYWORD][DESC]]
 FORMAT is a symbol for the export backend.
-Supported backends: 'html, 'latex, 'ascii, 'org, 'md" type type)
+Supported backends: 'html, 'latex, 'ascii, 'org, 'md, 'pandoc" type type)
      (cond
       ((eq format 'org)
        (mapconcat
@@ -1814,8 +1814,8 @@ Supported backends: 'html, 'latex, 'ascii, 'org, 'md" type type)
       ((eq format 'odt)
        (format "[%s]" keyword))
 
-      ;; for markdown we generate pandoc citations
-      ((eq format 'md)
+      ;; for markdown and pandoc we generate pandoc citations
+      ((or (eq format 'md) (eq format 'pandoc))
        (cond
   (desc ;; pre and or post text
    (let* ((text (split-string desc "::"))

--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -387,16 +387,16 @@ Argument KEY is the bibtex key."
         ;; I like this better than bibtex-url which does not always find
         ;; the urls
         (catch 'done
-          (let ((url (bibtex-autokey-get-field "url")))
-            (when  url
-              (browse-url (s-trim url))
+          (let ((url (s-trim (bibtex-autokey-get-field "url"))))
+            (unless (s-blank? url)
+              (browse-url url)
               (throw 'done nil)))
 
-          (let ((doi (bibtex-autokey-get-field "doi")))
-            (when doi
+          (let ((doi (s-trim (bibtex-autokey-get-field "doi"))))
+            (unless (s-blank? doi)
               (if (string-match "^http" doi)
                   (browse-url doi)
-                (browse-url (format "http://dx.doi.org/%s" (s-trim doi))))
+                (browse-url (format "http://dx.doi.org/%s" doi)))
               (throw 'done nil))))))))
 
 


### PR DESCRIPTION
Fixes the case of trying to opening a url/doi belonging to a reference/citation under the point if the url field doesn't exists.

Additionally, export citations in pandoc citation format for the 'pandoc backend (https://github.com/kawabata/ox-pandoc).