### PR TITLE
When making a note, tell helm-bibtex which bibtex to use

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -240,8 +240,9 @@ for each entry.  It also tries to be compatible with `org-bibtex'.
 
 An alternative is
 (lambda (thekey)
-  (bibtex-completion-edit-notes
-   (list (car (org-ref-get-bibtex-key-and-file thekey)))))
+  (let ((bibtex-completion-bibliography (org-ref-find-bibliography)))
+    (bibtex-completion-edit-notes
+     (list (car (org-ref-get-bibtex-key-and-file thekey))))))
 
 Use that if you prefer the `bibtex-completion' approach, which also
 supports an additional method for storing notes. See


### PR DESCRIPTION
(by analogy with org-ref-helm-bibtex) - to prevent the possibility that
helm-bibtex doesn't find the bibtex file which org-ref is using when
adding a note.

Tweak to the customise instructions for users using helm-bibtex as notes backend.