### PR TITLE
Support pdf download from new IEEE-links

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -423,6 +423,20 @@ REDIRECT-URL is where the pdf url will be in."
             (when (re-search-forward "<frame src=\"\\(http[[:ascii:]]*?\\)\"" nil t)
               (match-string 1))))))))
 
+;; At least some IEEE papers need the following new pdf-link parsing
+;; Example: 10.1109/35.667413
+(defun ieee2-pdf-url (*doi-utils-redirect*)
+  "Get a url to the pdf from *DOI-UTILS-REDIRECT* for IEEE urls."
+  (when (string-match "^http://ieeexplore.ieee.org" *doi-utils-redirect*)
+    (with-current-buffer (url-retrieve-synchronously *doi-utils-redirect*)
+      (goto-char (point-min))
+      (when (re-search-forward "\"pdfUrl\":\"\\([[:ascii:]]*?\\)\"" nil t)
+    (let ((framed-url (match-string 1)))
+          (with-current-buffer (url-retrieve-synchronously (concat "http://ieeexplore.ieee.org" framed-url))
+            (goto-char (point-min))
+            (when (re-search-forward "<frame src=\"\\(http[[:ascii:]]*?\\)\"" nil t)
+              (match-string 1))))))))
+
 ;; ACM Digital Library
 ;; http://dl.acm.org/citation.cfm?doid=1368088.1368132
 ;; <a name="FullTextPDF" title="FullText PDF" href="ft_gateway.cfm?id=1368132&ftid=518423&dwn=1&CFID=766519780&CFTOKEN=49739320" target="_blank">
@@ -460,6 +474,7 @@ REDIRECT-URL is where the pdf url will be in."
        'sage-pdf-url
        'jneurosci-pdf-url
        'ieee-pdf-url
+       'ieee2-pdf-url
        'acm-pdf-url
        'generic-full-pdf-url))
 


### PR DESCRIPTION
Add a pdf-link parser function for new IEEExplore links. The old
function is still in place to make sure IEEE papers which use the old
scheme should still work (if such links exist).

Fix #331