### PR TITLE
Add journal field to arxiv-entry-format-string

### DIFF
--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -95,6 +95,7 @@
 ;; extracts the necessary information, and formats a new BibTeX entry.
 
 (defvar arxiv-entry-format-string "@article{%s,
+  journal = {CoRR},
   title = {%s},
   author = {%s},
   archivePrefix = {arXiv},


### PR DESCRIPTION
The format-string uses the BibTex article type, which is required to contain a journal field. See [Wikipedia](https://en.wikipedia.org/wiki/BibTeX#Entry_types)

arXiv papers are automatically published in the CoRR journal ( http://oldwww.acm.org/corr/ )

dblp also uses the CoRR journal field for arXiv papers. ( http://dblp.uni-trier.de/db/journals/corr/index.html )