### PR TITLE
Improve pre/post text support

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -3288,6 +3288,26 @@ move to the beginning of the previous cite link after this one."
        ""))))
 
 
+(defun org-ref-update-pre-post-text ()
+  "Prompt for pre/post text and update link accordingly.
+A blank string deletes pre/post text."
+  (save-excursion
+    (let* ((cite (org-element-context))
+	   (type (org-element-property :type cite))
+	   (key (org-element-property :path cite))
+	   (text (read-from-minibuffer "Pre/post text: ")))
+      ;; First we delete the citation
+      (when (-contains? org-ref-cite-types type)
+	(cl--set-buffer-substring
+	 (org-element-property :begin cite)
+	 (org-element-property :end cite)
+	 ""))
+      ;; Then we reformat the citation
+      (if (string= text "")
+	  (insert (format "%s:%s" type key))
+	(insert (format "[[%s:%s][%s]]" type key text))))))
+
+
 (defun org-ref-delete-key-at-point ()
   "Delete the key at point."
   (save-excursion

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -378,7 +378,7 @@ the completion sources in the background so the initial call to ‘org-ref-helm-
 
 
 ;;;###autoload
-(defun org-ref-helm-insert-cite-link (arg)
+(defun org-ref-helm-insert-cite-link (&optional arg)
   "Insert a citation link with `helm-bibtex'.
 With one prefix ARG, insert a ref link.
 With two prefix ARGs, insert a label link."

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -463,6 +463,11 @@ Checks for pdf and doi, and add appropriate functions."
      '("Delete citation at point" . org-ref-delete-cite-at-point)
      candidates)
 
+    (when bibtex-completion-cite-prompt-for-optional-arguments
+      (cl-pushnew
+       '("Update pre/post text" . org-ref-update-pre-post-text)
+       candidates))
+
     (cl-pushnew
      '("Sort keys by year" . org-ref-sort-citation-link)
      candidates)

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -283,6 +283,56 @@ change the key at point to the selected keys."
   "")
 
 
+(defun org-ref-format-citation (keys)
+  "Formatter for org-ref citation commands.
+Prompt for the command and additional arguments if the commands can
+take any. If point is inside a citation link, append KEYS. Otherwise
+prompt for pre/post text. Prompts can also be switched off by setting
+the variable `bibtex-completion-cite-prompt-for-optional-arguments' to
+nil. To enable this formatter, add it to
+`bibtex-completion-format-citation-functions'. For example:
+
+\(setf (cdr (assoc 'org-mode bibtex-completion-format-citation-functions)) 'org-ref-format-citation)
+
+Note also that pre text is preceded by a double colon, for example:
+
+\[[cite:key][See::Chapter 1]], which exports to:
+
+\\cite[See][Chapter 1]{key}."
+  ;; Check if point is inside a cite link
+  (let ((link (org-element-context)))
+    (if (-contains? org-ref-cite-types (org-element-property :type link))
+	(progn
+	  (setq end (org-element-property :end link)
+		path (org-element-property :path link))
+	  (goto-char end)
+	  ;; Check if link has pre/post text
+	  (if (looking-back "\]")
+	      (progn
+		(re-search-backward path nil t)
+		(re-search-forward "\]" nil t)
+		(backward-char 1)
+		(format ",%s" (s-join "," keys))))
+	  (format ",%s" (s-join "," keys)))
+      (let* ((initial (when bibtex-completion-cite-default-as-initial-input bibtex-completion-cite-default-command))
+	     (default
+	       (unless bibtex-completion-cite-default-as-initial-input bibtex-completion-cite-default-command))
+	     (default-info
+	       (if default (format " (default \"%s\")" default) ""))
+	     (cite-command
+	      (completing-read (format "Cite command%s: " default-info)
+			       bibtex-completion-cite-commands nil nil initial
+			       'bibtex-completion-cite-command-history default nil)))
+	(if (member cite-command '("nocite" "supercite"))  ; These don't want arguments.
+	    (format "%s:%s" cite-command (s-join "," keys))
+	  (let ((text (if bibtex-completion-cite-prompt-for-optional-arguments
+			  (read-from-minibuffer "Pre/post text: ")
+			"")))
+	    (if (string= "" text)
+		(format "%s:%s" cite-command (s-join "," keys))
+	      (format "[[%s:%s][%s]]" cite-command (s-join "," keys) text))))))))
+
+
 ;;;###autoload
 (defun org-ref-helm-load-completions-async ()
   "Load the bibtex files into helm sources asynchronously.

--- a/org-ref.org
+++ b/org-ref.org
@@ -73,8 +73,6 @@ If you want to /replace/ an existing key in a citation, put the cursor on the ke
 [[index:cite!shift]]
 Finally, if you do not like the order of the keys in a citation, you can put your cursor on a key and use shift-arrows (left or right) to move the key around. Alternatively, you can run the command ~org-ref-sort-citation-link~ which will sort the keys by year, oldest to newest.
 
-org-ref has basic and limited support for pre/post text in citations. You can get pre/post text by using a description in a cite link, with pre/post text separated by ::. For example, [[cite:Dominik201408][See page 20::, for example]]. It is not easy (maybe not possible) to extend this for the humanities style of citations (e.g. harvard) with nested pre/post text on multiple citations. If anyone knows how to do it, pull requests are welcome! There is an ongoing effort in org-mode for a new citation syntax that may make this more feasible.
-
 You may want to bind a hydra menu to a key-binding or key-chord. For example:
 
 #+BEGIN_SRC emacs-lisp
@@ -82,6 +80,18 @@ You may want to bind a hydra menu to a key-binding or key-chord. For example:
 #+END_SRC
 
 This will allow you to quickly press ~kk~ while on a cite link to access functions that can act on the link.
+
+*** Pre/post text support
+
+org-ref has basic and limited support for pre/post text in citations. You can get pre/post text by using a description in a cite link, with pre/post text separated by ::. For example, [[cite:Dominik201408][See page 20::, for example]]. It is not easy (maybe not possible) to extend this for the humanities style of citations (e.g. harvard) with nested pre/post text on multiple citations. If anyone knows how to do it, pull requests are welcome! There is an ongoing effort in org-mode for a new citation syntax that may make this more feasible.
+
+If you use helm-bibtex and would like pre/post text support enabled, you can add ~org-ref-format-citation~ to ~bibtex-completion-format-citation-functions~:
+
+#+BEGIN_SRC emacs-lisp
+(setf (cdr (assoc 'org-mode bibtex-completion-format-citation-functions)) 'org-ref-format-citation)
+#+END_SRC
+
+See also: [[https://github.com/tmalsburg/helm-bibtex#format-of-citations][Format of citations]] and [[https://github.com/tmalsburg/helm-bibtex#latex-citation-commands][Insert LaTeX cite commands]]. Note that pre/post prompt can also be switched off by setting the variable ~bibtex-completion-cite-prompt-for-optional-arguments~ to nil.
 
 *** label links
 index:label


### PR DESCRIPTION
To test:

`(setf (cdr (assoc 'org-mode bibtex-completion-format-citation-functions)) 'org-ref-format-citation)`

1. M-x helm-bibtex
2. Insert citation
3. Add pre/post text

I also added the option to update pre/post text as a click action, but it is only displayed if `bibtex-completion-cite-prompt-for-optional-arguments` is t.
