### PR TITLE
Adds CrossRef Lookup from 'pdf-tools' highlighted text.

### DIFF
--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -234,5 +234,15 @@ variable `org-ref-pdf-doi-regex'."
   (occur org-ref-pdf-doi-regex)
   (switch-to-buffer-other-window "*Occur*"))
 
+;;;###autoload
+(defun org-ref-pdf-crossref-lookup ()
+	"Lookup highlighted text in PDFView in CrossRef."
+	(interactive)
+	(pdf-view-assert-active-region)
+	(let* ((txt (pdf-view-active-region-text)))
+		(pdf-view-deactivate-region)
+		(crossref-lookup (mapconcat 'identity txt "	 \n"))))
+
+
 (provide 'org-ref-pdf)
 ;;; org-ref-pdf.el ends here


### PR DESCRIPTION
Unfortunately, from my testing the `*-at-point` commands do not work on PDFs. `pdf-tools` for example would always return `%PDF1.4%` as the text. Therefore, I added this code which works with pdf-tools. I have only added CrossRef as the best at handling the freeform citations, but I'd be happy to add them all if others are interested. I find that it speeds up my workflow so I figured somebody could benefit from it as well.

Cheers!