### PR TITLE
[doi-utils] fix IOP pdf url parse

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -272,11 +272,7 @@ Argument REDIRECT-URL URL you are redirected to."
 (defun iop-pdf-url (*doi-utils-redirect*)
   "Get url to the pdf from *DOI-UTILS-REDIRECT*."
   (when (string-match "^http://iopscience.iop.org" *doi-utils-redirect*)
-    (let ((tail (replace-regexp-in-string
-                 "^http://iopscience.iop.org" "" *doi-utils-redirect*)))
-      (concat "http://iopscience.iop.org" tail
-              "/pdf" (replace-regexp-in-string "/" "_" tail) ".pdf"))))
-
+    (replace-regexp-in-string "/meta" "/pdf" *doi-utils-redirect*)))
 
 ;;** JSTOR
 

--- a/x.sh
+++ b/x.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh 
 # copied from https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw
 # To make sure I have it
 #


### PR DESCRIPTION
I was having issues with doi-utils-get-bibtex-entry-pdf for IOP journals (primarily J Phys A). I was getting links in *doi-utils-redirect* like

http://iopscience.iop.org/article/10.1088/1751-8113/48/43/435202/meta

Which only need the meta to be replaced with a pdf in order to access the PDF file rather than the complicated code that was present (and not working). I'm not 100% on how all the DOI stuff works: If I need to do more in order to start getting this fix incorporated, let me know.