### PR TITLE
Add macro org-ref-link-set-parameters

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -49,6 +49,7 @@
 (require 'org)                          ; org-add-link-type
 (require 'org-bibtex)                   ; org-bibtex-yank
 (require 'url-http)
+(require 'org-ref-utils)
 
 ;;; Code:
 
@@ -1084,38 +1085,20 @@ Argument LINK-STRING Passed in on link click."
         2)
        link-string))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "doi"
-     :follow #'doi-link-menu
-     :export (lambda (doi desc format)
-	       (cond
-		((eq format 'html)
-		 (format "<a href=\"%s%s\">%s</a>"
-			 doi-utils-dx-doi-org-url
-			 doi
-			 (or desc (concat "doi:" doi))))
-		((eq format 'latex)
-		 (format "\\href{%s%s}{%s}"
-			 doi-utils-dx-doi-org-url
-			 doi
-			 (or desc (concat "doi:" doi)))))))
-  (org-add-link-type
-   "doi"
-   'doi-link-menu
-   (lambda (doi desc format)
-     (cond
-      ((eq format 'html)
-       (format "<a href=\"%s%s\">%s</a>"
-	       doi-utils-dx-doi-org-url
-	       doi
-	       (or desc (concat "doi:" doi))))
-      ((eq format 'latex)
-       (format "\\href{%s%s}{%s}"
-	       doi-utils-dx-doi-org-url
-	       doi
-	       (or desc (concat "doi:" doi))))))))
-
+(org-ref-link-set-parameters "doi"
+  :follow #'doi-link-menu
+  :export (lambda (doi desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"%s%s\">%s</a>"
+                      doi-utils-dx-doi-org-url
+                      doi
+                      (or desc (concat "doi:" doi))))
+             ((eq format 'latex)
+              (format "\\href{%s%s}{%s}"
+                      doi-utils-dx-doi-org-url
+                      doi
+                      (or desc (concat "doi:" doi)))))))
 
 ;;* Getting a doi for a bibtex entry missing one
 

--- a/nist-webbook.el
+++ b/nist-webbook.el
@@ -8,6 +8,7 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-ref-utils)
 
 ;;;###autoload
 (defun nist-webbook-formula (formula)
@@ -28,16 +29,13 @@
            (url-hexify-string name)
            "&Units=SI")))
 
+(org-ref-link-set-parameters "nist-wb-name"
+  :follow (lambda (name)
+            (nist-webbook-name name)))
 
-(org-add-link-type
- "nist-wb-name"
- (lambda (name)
-   (nist-webbook-name name)))
-
-(org-add-link-type
- "nist-wb-formula"
- (lambda (formula)
-   (nist-webbook-formula formula)))
+(org-ref-link-set-parameters "nist-wb-formula"
+  :follow (lambda (formula)
+            (nist-webbook-formula formula)))
 
 (provide 'nist-webbook)
 

--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -30,6 +30,7 @@
 (require 'f)
 (require 'org)
 (require 's)
+(require 'org-ref-utils)
 
 ;; This is a local variable defined in `url-http'.  We need it to avoid
 ;; byte-compiler errors.
@@ -40,21 +41,17 @@
 ;;* The org-mode link
 ;; this just makes a clickable link that opens the entry.
 ;; example: arxiv:cond-mat/0410285
-(org-add-link-type
- "arxiv"
- ;; clicking
- (lambda (link-string)
-   (browse-url (format "http://arxiv.org/abs/%s" link-string)))
- ;; formatting
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format  "<a href=\"http://arxiv.org/abs/%s\">arxiv:%s</a>"
-	      keyword  (or desc keyword)))
-    ((eq format 'latex)
-     ;; write out the latex command
-     (format "\\url{http://arxiv.org/abs/%s}{%s}" keyword (or desc keyword))))))
-
+(org-ref-link-set-parameters "arxiv"
+  :follow (lambda (link-string)
+            (browse-url (format "http://arxiv.org/abs/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format  "<a href=\"http://arxiv.org/abs/%s\">arxiv:%s</a>"
+                       keyword  (or desc keyword)))
+             ((eq format 'latex)
+              ;; write out the latex command
+              (format "\\url{http://arxiv.org/abs/%s}{%s}" keyword (or desc keyword))))))
 
 ;;* Getting a bibtex entry for an arXiv article using remote service:
 ;; For an arxiv article, there is a link to a NASA ADS page like this:

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -918,31 +918,18 @@ ARG does nothing. I think it is a required signature."
 	    (or (mapconcat #'identity found ",")
 		(read-file-name "enter file: " nil nil nil)))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "bibliography"
-     :follow #'org-ref-open-bibliography
-     :export #'org-ref-bibliography-format
-     :complete #'org-bibliography-complete-link
-     :help-echo (lambda (window object position)
-		  (save-excursion
-		    (goto-char position)
-		    (let ((s (org-ref-link-message)))
-		      (with-temp-buffer
-			(insert s)
-			(fill-paragraph)
-			(buffer-string))))))
-  ;; org 8
-  (org-add-link-type
-   "bibliography"
-   ;; this code is run on clicking. The bibliography
-   ;; may contain multiple files. this code finds the
-   ;; one you clicked on and opens it.
-   #'org-ref-open-bibliography
-   ;; formatting code
-   #'org-ref-bibliography-format))
-
+(org-ref-link-set-parameters "bibliography"
+  :follow #'org-ref-open-bibliography
+  :export #'org-ref-bibliography-format
+  :complete #'org-bibliography-complete-link
+  :help-echo (lambda (window object position)
+               (save-excursion
+                 (goto-char position)
+                 (let ((s (org-ref-link-message)))
+                   (with-temp-buffer
+                     (insert s)
+                     (fill-paragraph)
+                     (buffer-string))))))
 
 (defun org-ref-nobibliography-format (keyword desc format)
   "Format function for nobibliography link export"
@@ -961,66 +948,30 @@ ARG does nothing. I think it is a required signature."
 				(split-string keyword ","))
 			","))))))
 
+(org-ref-link-set-parameters "nobibliography"
+  :follow #'org-ref-open-bibliography
+  :export #'org-ref-nobibliography-format)
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "nobibliography"
-     :follow #'org-ref-open-bibliography
-     :export #'org-ref-nobibliography-format)
-  
-  (org-add-link-type
-   "nobibliography"
-   #'org-ref-open-bibliography
-   #'org-ref-nobibliography-format))
+(org-ref-link-set-parameters "printbibliography"
+  :follow #'org-ref-open-bibliography
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'org) (org-ref-get-org-bibliography))
+             ((eq format 'html) (org-ref-get-html-bibliography))
+             ((eq format 'latex)
+              ;; write out the biblatex bibliography command
+              "\\printbibliography"))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "printbibliography"
-     :follow #'org-ref-open-bibliography
-     :export (lambda (keyword desc format)
-	       (cond
-		((eq format 'org) (org-ref-get-org-bibliography))
-		((eq format 'html) (org-ref-get-html-bibliography))
-		((eq format 'latex)
-		 ;; write out the biblatex bibliography command
-		 "\\printbibliography"))))
-  (org-add-link-type
-   "printbibliography"
-   (lambda (arg) (message "Nothing implemented for clicking here."))
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'org) (org-ref-get-org-bibliography))
-      ((eq format 'html) (org-ref-get-html-bibliography))
-      ((eq format 'latex)
-       ;; write out the biblatex bibliography command
-       "\\printbibliography")))))
-
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "bibliographystyle"
-     :export (lambda (keyword desc format)
-	       (cond
-		((or (eq format 'latex)
-		     (eq format 'beamer))
-		 ;; write out the latex bibliography command
-		 (format "\\bibliographystyle{%s}" keyword))
-		;; Other styles should not have an output for this
-		(t
-		 ""))))
-  (org-add-link-type
-   "bibliographystyle"
-   (lambda (arg) (message "Nothing implemented for clicking here."))
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'latex)
-       ;; write out the latex bibliography command
-       (format "\\bibliographystyle{%s}" keyword))
-      ;; Other styles should not have an output for this
-      (t
-       "")))))
-
+(org-ref-link-set-parameters "bibliographystyle"
+  :export (lambda (keyword desc format)
+            (cond
+             ((or (eq format 'latex)
+                  (eq format 'beamer))
+              ;; write out the latex bibliography command
+              (format "\\bibliographystyle{%s}" keyword))
+             ;; Other styles should not have an output for this
+             (t
+              ""))))
 
 ;;;###autoload
 (defun org-ref-insert-bibliography-link ()
@@ -1072,27 +1023,14 @@ ARG does nothing. I think it is a required signature."
 		     (buffer-substring key-beginning key-end)))
       (find-file bibfile))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "addbibresource"
-     :follow #'org-ref-follow-addbibresource
-     :export (lambda (keyword desc format)
-	       (cond
-		((eq format 'html) (format ""))	; no output for html
-		((eq format 'latex)
-		 ;; write out the latex addbibresource command
-		 (format "\\addbibresource{%s}" keyword)))))
-  (org-add-link-type
-   "addbibresource"
-   'org-ref-follow-addbibresource 
-   ;; formatting code
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'html) (format ""))	; no output for html
-      ((eq format 'latex)
-       ;; write out the latex addbibresource command
-       (format "\\addbibresource{%s}" keyword))))))
-
+(org-ref-link-set-parameters "addbibresource"
+  :follow #'org-ref-follow-addbibresource
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html) (format "")) ; no output for html
+             ((eq format 'latex)
+              ;; write out the latex addbibresource command
+              (format "\\addbibresource{%s}" keyword)))))
 
 ;;** List of figures
 
@@ -1175,22 +1113,12 @@ Ignore figures in COMMENTED sections."
       (use-local-map (copy-keymap org-mode-map))
       (local-set-key "q" #'(lambda () (interactive) (kill-buffer))))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "list-of-figures"
-     :follow #'org-ref-list-of-figures
-     :export (lambda (keyword desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\listoffigures")))))
-  (org-add-link-type
-   "list-of-figures"
-   'org-ref-list-of-figures		; on click
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'latex)
-       (format "\\listoffigures"))))))
+(org-ref-link-set-parameters "list-of-figures"
+  :follow #'org-ref-list-of-figures
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\listoffigures")))))
 
 ;;** List of tables
 ;;;###autoload
@@ -1240,23 +1168,12 @@ ARG does nothing."
       (use-local-map (copy-keymap org-mode-map))
       (local-set-key "q" #'(lambda () (interactive) (kill-buffer))))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "list-of-tables"
-     :follow #'org-ref-list-of-tables
-     :export (lambda (keyword desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\listoftables")))))
-  (org-add-link-type
-   "list-of-tables"
-   'org-ref-list-of-tables
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'latex)
-       (format "\\listoftables"))))))
-
+(org-ref-link-set-parameters "list-of-tables"
+  :follow #'org-ref-list-of-tables
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\listoftables")))))
 
 ;;** label link
 (defun org-ref-count-labels (label)
@@ -1322,57 +1239,33 @@ ARG does nothing."
        :type "ref"
        :link (concat "ref:" (org-element-property :name object))))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "label"
-     :follow (lambda (label)
-	       "On clicking count the number of label tags used in the buffer.
+(org-ref-link-set-parameters "label"
+  :follow (lambda (label)
+            "On clicking count the number of label tags used in the buffer.
 A number greater than one means multiple labels!"
-	       (let ((count (org-ref-count-labels label)))
-		 (message (format "%s occurence%s"
-				  count
-				  (if (or (= count 0)
-					  (> count 1))
-				      "s"
-				    ""))
-			  (org-ref-count-labels label))))
-     :export (lambda (keyword desc format)
-	       (cond
-		((eq format 'html) (format "<div id=\"%s\">" keyword))
-		((eq format 'latex)
-		 (format "\\label{%s}" keyword))))
-     :store #'org-label-store-link
-     :face 'org-ref-label-face
-     :help-echo (lambda (window object position)
-		  (save-excursion
-		    (goto-char position)
-		    (let ((s (org-ref-link-message)))
-		      (with-temp-buffer
-			(insert s)
-			(fill-paragraph)
-			(buffer-string))))))
-  
-  (org-add-link-type
-   "label"
-   (lambda (label)
-     "On clicking count the number of label tags used in the buffer.
-A number greater than one means multiple labels!"
-     (let ((count (org-ref-count-labels label)))
-       (message (format "%s occurence%s"
-			count
-			(if (or (= count 0)
-				(> count 1))
-			    "s"
-			  ""))
-		(org-ref-count-labels label))))
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'html) (format "<div id=\"%s\">" keyword))
-      ((eq format 'latex)
-       (format "\\label{%s}" keyword)))))
-  (add-hook 'org-store-link-functions 'org-label-store-link))
-
+            (let ((count (org-ref-count-labels label)))
+              (message (format "%s occurence%s"
+                               count
+                               (if (or (= count 0)
+                                       (> count 1))
+                                   "s"
+                                 ""))
+                       (org-ref-count-labels label))))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html) (format "<div id=\"%s\">" keyword))
+             ((eq format 'latex)
+              (format "\\label{%s}" keyword))))
+  :store #'org-label-store-link
+  :face 'org-ref-label-face
+  :help-echo (lambda (window object position)
+               (save-excursion
+                 (goto-char position)
+                 (let ((s (org-ref-link-message)))
+                   (with-temp-buffer
+                     (insert s)
+                     (fill-paragraph)
+                     (buffer-string))))))
 
 ;;** ref link
 (defun org-ref-ref-follow (label)
@@ -1460,25 +1353,12 @@ Optional argument ARG Does nothing."
    ((eq format 'latex)
     (format "\\ref{%s}" keyword))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "ref"
-     :follow #'org-ref-ref-follow
-     :export #'org-ref-ref-export
-     :complete #'org-ref-complete-link
-     :face 'org-ref-ref-face
-     :help-echo #'org-ref-ref-help-echo)
-  
-  (org-add-link-type
-   "ref"
-   #'org-ref-ref-follow
-   (lambda (keyword desc format)
-     (cond
-      ((eq format 'html) (format "<a href=\"#%s\">%s</a>" keyword keyword))
-      ((eq format 'latex)
-       (format "\\ref{%s}" keyword))))))
-
+(org-ref-link-set-parameters "ref"
+  :follow #'org-ref-ref-follow
+  :export #'org-ref-ref-export
+  :complete #'org-ref-complete-link
+  :face 'org-ref-ref-face
+  :help-echo #'org-ref-ref-help-echo)
 
 (defun org-ref-get-org-labels ()
   "Return a list of #+LABEL: labels."
@@ -1615,27 +1495,17 @@ This is used to complete ref links."
     (org-mark-ring-goto)
     (error "%s not found" label))
   (message "go back with (org-mark-ring-goto) `C-c &`"))
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "pageref"
-     :follow #'org-ref-follow-pageref
-     :export (lambda (path desc format)
-	       (cond
-		((eq format 'html) (format "(<pageref>%s</pageref>)" path))
-		((eq format 'latex)
-		 (format "\\pageref{%s}" path))))
-     :face 'org-ref-ref-face
-     :complete #'org-pageref-complete-link
-     :help-echo #'org-ref-ref-help-echo)
-  (org-add-link-type
-   "pageref"
-   #'org-ref-follow-pageref 
-   (lambda (path desc format)
-     (cond
-      ((eq format 'html) (format "(<pageref>%s</pageref>)" path))
-      ((eq format 'latex)
-       (format "\\pageref{%s}" path))))))
 
+(org-ref-link-set-parameters "pageref"
+  :follow #'org-ref-follow-pageref
+  :export (lambda (path desc format)
+            (cond
+             ((eq format 'html) (format "(<pageref>%s</pageref>)" path))
+             ((eq format 'latex)
+              (format "\\pageref{%s}" path))))
+  :face 'org-ref-ref-face
+  :complete #'org-pageref-complete-link
+  :help-echo #'org-ref-ref-help-echo)
 
 (defun org-pageref-complete-link (&optional arg)
   "Completion function for ref links.
@@ -1676,18 +1546,12 @@ Optional argument ARG Does nothing."
    ((eq format 'latex)
     (format "\\nameref{%s}" path))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "nameref"
-     :follow #'org-ref-follow-nameref
-     :export #'org-ref-export-nameref
-     :complete #'org-ref-complete-link
-     :face 'org-ref-ref-face
-     :help-echo #'org-ref-ref-help-echo)
-  (org-add-link-type
-   "nameref"
-   #'org-ref-follow-nameref
-   #'org-ref-export-nameref))
+(org-ref-link-set-parameters "nameref"
+  :follow #'org-ref-follow-nameref
+  :export #'org-ref-export-nameref
+  :complete #'org-ref-complete-link
+  :face 'org-ref-ref-face
+  :help-echo #'org-ref-ref-help-echo)
 
 ;;** eqref link
 
@@ -1717,19 +1581,13 @@ Optional argument ARG Does nothing."
    ;;customize the variable 'org-html-mathjax-template' and 'org-html-mathjax-options' refering to  'autonumber'
    ((eq format 'html) (format "\\eqref{%s}" keyword))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "eqref"
-     :follow #'org-ref-eqref-follow
-     :export #'org-ref-eqref-export
-     ;; This isn't equation specific, one day we might try to make it that way.
-     :complete #'org-ref-complete-link
-     :face 'org-ref-ref-face
-     :help-echo #'org-ref-ref-help-echo)
-  (org-add-link-type
-   "eqref"
-   #'org-ref-eqref-follow
-   #'org-ref-eqref-export))
+(org-ref-link-set-parameters "eqref"
+  :follow #'org-ref-eqref-follow
+  :export #'org-ref-eqref-export
+  ;; This isn't equation specific, one day we might try to make it that way.
+  :complete #'org-ref-complete-link
+  :face 'org-ref-ref-face
+  :help-echo #'org-ref-ref-help-echo)
 
 ;;** autoref link
 
@@ -1763,18 +1621,12 @@ Optional argument ARG Does nothing."
    ;;'autonumber'
    ((eq format 'html) (format "\\autoref{%s}" keyword))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "autoref"
-     :follow #'org-ref-autoref-follow
-     :export #'org-ref-autoref-export
-     :complete #'org-ref-complete-link
-     :face 'org-ref-ref-face
-     :help-echo #'org-ref-ref-help-echo)
-  (org-add-link-type
-   "autoref"
-   #'org-ref-autoref-follow
-   #'org-ref-autoref-export))
+(org-ref-link-set-parameters "autoref"
+  :follow #'org-ref-autoref-follow
+  :export #'org-ref-autoref-export
+  :complete #'org-ref-complete-link
+  :face 'org-ref-ref-face
+  :help-echo #'org-ref-ref-help-echo)
 
 ;;** cite link
 
@@ -2186,24 +2038,13 @@ Save in the default link type."
     (car org-stored-links)))
 
 ;;* Index link
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "index"
-     :follow (lambda (path)
-	       (occur path))
-     :export (lambda (path desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\index{%s}" path)))))
-  (org-add-link-type
-   "index"
-   (lambda (path)
-     (occur path))
-
-   (lambda (path desc format)
-     (cond
-      ((eq format 'latex)
-       (format "\\index{%s}" path))))))
+(org-ref-link-set-parameters "index"
+  :follow (lambda (path)
+            (occur path))
+  :export (lambda (path desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\index{%s}" path)))))
 
 ;; this will generate a temporary index of entries in the file when clicked on.
 ;;;###autoload
@@ -2264,23 +2105,12 @@ PATH is required for the org-link, but it does nothing here."
 	  (insert (format "%s %s\n\n" (car link) (cdr link))))))
     (switch-to-buffer "*index*")))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "printindex"
-     :follow #'org-ref-index
-     :export (lambda (path desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "printindex")))))
-  (org-add-link-type
-   "printindex"
-   'org-ref-index
-   ;; formatting
-   (lambda (path desc format)
-     (cond
-      ((eq format 'latex)
-       (format "printindex"))))))
+(org-ref-link-set-parameters "printindex"
+  :follow #'org-ref-index
+  :export (lambda (path desc format)
+            (cond
+             ((eq format 'latex)
+              (format "printindex")))))
 
 ;;* Utilities
 ;;** create text citations from a bibtex entry

--- a/org-ref-glossary.el
+++ b/org-ref-glossary.el
@@ -71,6 +71,7 @@
 ;; Acp:label (exports to \Glspl{label})
 
 (require 'org-element)
+(require 'org-ref-utils)
 
 ;;; Code:
 (defgroup org-ref-glossary nil
@@ -185,140 +186,72 @@ Entry gets added after the last #+latex_header line."
 
 
 ;; link to glossary entry
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "gls"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\gls{%s}" path)))))
-  (org-add-link-type
-   "gls"
-   'or-follow-glossary
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\gls{%s}" path))))))
-
+(org-ref-link-set-parameters "gls"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\gls{%s}" path)))))
 
 ;; plural
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "glspl"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\glspl{%s}" path)))))
-  (org-add-link-type
-   "glspl"
-   'or-follow-glossary
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\glspl{%s}" path))))))
-
+(org-ref-link-set-parameters "glspl"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\glspl{%s}" path)))))
 
 ;; capitalized link
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "Gls"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\Gls{%s}" path)))))
-  (org-add-link-type
-   "Gls"
-   'or-follow-glossary
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\Gls{%s}" path))))))
+(org-ref-link-set-parameters "Gls"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\Gls{%s}" path)))))
 
 ;; capitalized plural link
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "Glspl"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\Glspl{%s}" path)))))
-  (org-add-link-type
-   "Glspl"
-   'or-follow-glossary
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\Glspl{%s}" path))))))
+(org-ref-link-set-parameters "Glspl"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\Glspl{%s}" path)))))
 
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "glslink"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\glslink{%s}{%s}" path desc)))))
-  (org-add-link-type
-   "glslink"
-   'or-follow-glossary
-   (lambda (path desc format)
-     (cond
-      ((eq format 'latex)
-       (format "\\glslink{%s}{%s}" path desc))))))
+(org-ref-link-set-parameters "glslink"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\glslink{%s}{%s}" path desc)))))
 
+(org-ref-link-set-parameters "glssymbol"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\glssymbol{%s}" path)))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "glssymbol"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _desc format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\glssymbol{%s}" path)))))
-  (org-add-link-type
-   "glssymbol"
-   'or-follow-glossary
-   (lambda (path _desc format)
-     (cond
-      ((eq format 'latex)
-       (format "\\glssymbol{%s}" path))))))
-
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "glsdesc"
-     :follow #'or-follow-glossary
-     :face 'org-ref-glossary-face
-     :help-echo 'or-glossary-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\glsdesc{%s}" path)))))
-  (org-add-link-type
-   "glsdesc"
-   'or-follow-glossary
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\glsdesc{%s}" path))))))
-
+(org-ref-link-set-parameters "glsdesc"
+  :follow #'or-follow-glossary
+  :face 'org-ref-glossary-face
+  :help-echo 'or-glossary-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\glsdesc{%s}" path)))))
 
 ;;** Tooltips on glossary entries
 (defface org-ref-glossary-face
@@ -425,140 +358,68 @@ FULL is the expanded acronym."
   (re-search-forward (format "\\\\newacronym{%s}" label))
   (goto-char (match-beginning 0)))
 
+(org-ref-link-set-parameters "acrshort"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\acrshort{%s}" path)))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "acrshort"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\acrshort{%s}" path)))))
-  (org-add-link-type
-   "acrshort"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\acrshort{%s}" path))))))
+(org-ref-link-set-parameters "acrlong"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\acrlong{%s}" path)))))
 
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "acrlong"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\acrlong{%s}" path)))))
-  (org-add-link-type
-   "acrlong"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\acrlong{%s}" path))))))
-
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "acrfull"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\acrfull{%s}" path)))))
-  (org-add-link-type
-   "acrfull"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\acrfull{%s}" path))))))
-
+(org-ref-link-set-parameters "acrfull"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\acrfull{%s}" path)))))
 ;; Shortcuts
+(org-ref-link-set-parameters "ac"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\gls{%s}" path)))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "ac"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\gls{%s}" path)))))
-  (org-add-link-type
-   "ac"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\gls{%s}" path))))))
+(org-ref-link-set-parameters "Ac"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\Gls{%s}" path)))))
 
+(org-ref-link-set-parameters "acp"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\glspl{%s}" path)))))
 
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "Ac"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\Gls{%s}" path)))))
-  (org-add-link-type
-   "Ac"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\Gls{%s}" path))))))
-
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "acp"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\glspl{%s}" path)))))
-  (org-add-link-type
-   "acp"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\glspl{%s}" path))))))
-
-
-(if (fboundp 'org-link-set-parameters)
-    (org-link-set-parameters
-     "Acp"
-     :follow #'or-follow-acronym
-     :face 'org-ref-acronym-face
-     :help-echo 'or-acronym-tooltip
-     :export (lambda (path _ format)
-	       (cond
-		((eq format 'latex)
-		 (format "\\Glspl{%s}" path)))))
-  (org-add-link-type
-   "Acp"
-   'or-follow-acronym
-   (lambda (path _ format)
-     (cond
-      ((eq format 'latex)
-       (format "\\Glspl{%s}" path))))))
-
+(org-ref-link-set-parameters "Acp"
+  :follow #'or-follow-acronym
+  :face 'org-ref-acronym-face
+  :help-echo 'or-acronym-tooltip
+  :export (lambda (path _ format)
+            (cond
+             ((eq format 'latex)
+              (format "\\Glspl{%s}" path)))))
 
 ;;** Tooltips on acronyms
 (defface org-ref-acronym-face

--- a/org-ref-pubmed.el
+++ b/org-ref-pubmed.el
@@ -51,19 +51,17 @@
 
 (require 'dash)
 (require 'org)
+(require 'org-ref-utils)
 
-(org-add-link-type
- "pmid"
- ;; clicking
- (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pubmed/%s" link-string)))
- ;; formatting
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s\">pmid:%s</a>" keyword (or desc keyword))) ; no output for html
-    ((eq format 'latex)
-     ;; write out the latex command
-     (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s}{%s}" keyword (or desc keyword))))))
+(org-ref-link-set-parameters "pmid"
+  :follow (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pubmed/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s\">pmid:%s</a>" keyword (or desc keyword))) ; no output for html
+             ((eq format 'latex)
+              ;; write out the latex command
+              (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s}{%s}" keyword (or desc keyword))))))
 
 ;;** Get MEDLINE metadata
 
@@ -192,17 +190,14 @@ You must clean the entry after insertion."
 ;; Here we define a new link. Clicking on it simply opens a webpage to the
 ;; article.
 
-(org-add-link-type
- "pmcid"
- ;; clicking
- (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pmc/articles/%s" link-string)))
- ;; formatting
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/%s\">pmcid:%s</a>" keyword (or desc keyword)))
-    ((eq format 'latex)
-     (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/%s}{%s}" keyword (or desc keyword))))))
+(org-ref-link-set-parameters "pmcid"
+  :follow (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pmc/articles/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/%s\">pmcid:%s</a>" keyword (or desc keyword)))
+             ((eq format 'latex)
+              (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/%s}{%s}" keyword (or desc keyword))))))
 
 ;;* NIHMSID
 
@@ -213,18 +208,15 @@ You must clean the entry after insertion."
 ;; inclusion in PMC and the corresponding citation is in PubMed, the article
 ;; will also be assigned a PMCID.
 
-(org-add-link-type
- "nihmsid"
- ;; clicking
- (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s" link-string)))
- ;; formatting
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/mid//%s\">nihmsid:%s</a>" keyword (or desc keyword)))
-    ((eq format 'latex)
-     ;; write out the latex command
-     (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s}{%s}" keyword (or desc keyword))))))
+(org-ref-link-set-parameters "nihmsid"
+  :follow (lambda (link-string) (browse-url (format "http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://www.ncbi.nlm.nih.gov/pmc/articles/mid//%s\">nihmsid:%s</a>" keyword (or desc keyword)))
+             ((eq format 'latex)
+              ;; write out the latex command
+              (format "\\url{http://www.ncbi.nlm.nih.gov/pmc/articles/mid/%s}{%s}" keyword (or desc keyword))))))
 
 
 ;;* Searching pubmed
@@ -251,18 +243,17 @@ You must clean the entry after insertion."
    (format "http://www.ncbi.nlm.nih.gov/pubmed/?term=%s" (url-hexify-string query))))
 
 
-(org-add-link-type
- "pubmed-search"
- (lambda (query)
-   "Open QUERY in a `pubmed-simple-search'."
-   (pubmed-simple-search query))
- (lambda (query desc format)
-   (let ((url (format "http://www.ncbi.nlm.nih.gov/pubmed/?term=%s" (url-hexify-string query))))
-     (cond
-      ((eq format 'html)
-       (format "<a href=\"%s\">%s</a>" url (or desc (concat "pubmed-search:" query))))
-      ((eq format 'latex)
-       (format "\\href{%s}{%s}" url (or desc (concat "pubmed-search:" query))))))))
+(org-ref-link-set-parameters "pubmed-search"
+  :follow (lambda (query)
+            "Open QUERY in a `pubmed-simple-search'."
+            (pubmed-simple-search query))
+  :export (lambda (query desc format)
+            (let ((url (format "http://www.ncbi.nlm.nih.gov/pubmed/?term=%s" (url-hexify-string query))))
+              (cond
+               ((eq format 'html)
+                (format "<a href=\"%s\">%s</a>" url (or desc (concat "pubmed-search:" query))))
+               ((eq format 'latex)
+                (format "\\href{%s}{%s}" url (or desc (concat "pubmed-search:" query))))))))
 
 (provide 'org-ref-pubmed)
 ;;; org-ref-pubmed.el ends here

--- a/org-ref-sci-id.el
+++ b/org-ref-sci-id.el
@@ -27,29 +27,28 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-ref-utils)
 
-(org-add-link-type
- "orcid"
- (lambda
-   (link-string)
-   (browse-url
-    (format "http://orcid.org/%s" link-string)))
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://orcid.org/%s\">orcid:%s</a>" keyword (or desc keyword))))))
+(org-ref-link-set-parameters "orcid"
+  :follow (lambda
+            (link-string)
+            (browse-url
+             (format "http://orcid.org/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://orcid.org/%s\">orcid:%s</a>" keyword (or desc keyword))))))
 
-(org-add-link-type
- "researcherid"
- (lambda
-   (link-string)
-   (browse-url
-    (format "http://www.researcherid.com/rid/%s" link-string)))
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://www.researcherid.com/rid/%s\">ResearcherID:%s</a>"
-             keyword (or desc keyword))))))
+(org-ref-link-set-parameters "researcherid"
+  :follow (lambda
+            (link-string)
+            (browse-url
+             (format "http://www.researcherid.com/rid/%s" link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://www.researcherid.com/rid/%s\">ResearcherID:%s</a>"
+                      keyword (or desc keyword))))))
 
 (provide 'org-ref-sci-id)
 ;;; org-ref-sci-id.el ends here

--- a/org-ref-scopus.el
+++ b/org-ref-scopus.el
@@ -31,6 +31,7 @@
 (require 'org)
 (require 'hydra)
 (require 'xml)
+(require 'org-ref-utils)
 
 ;; avoiding byte-compiler warnings/errors
 ;;scopus.el:49:1:Warning: Unused lexical variable `url-request-extra-headers'
@@ -163,69 +164,63 @@ Requires `*scopus-api-key*' to be defined."
    "Citing articles"))
 
 
-(org-add-link-type
- "eid"
- (lambda (eid)
-   "Opens the hydra menu."
-   (setq *hydra-eid* eid)
-   (scopus-hydra/body))
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\" http://www.scopus.com/record/display.url?eid=%s&origin=resultslist\">%s</a>" keyword (or desc keyword)))
-    ((eq format 'latex)
-     (format "\\href{http://www.scopus.com/record/display.url?eid=%s&origin=resultslist}{%s}"
-             keyword (or desc keyword))))))
+(org-ref-link-set-parameters "eid"
+  :follow (lambda (eid)
+            "Opens the hydra menu."
+            (setq *hydra-eid* eid)
+            (scopus-hydra/body))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\" http://www.scopus.com/record/display.url?eid=%s&origin=resultslist\">%s</a>" keyword (or desc keyword)))
+             ((eq format 'latex)
+              (format "\\href{http://www.scopus.com/record/display.url?eid=%s&origin=resultslist}{%s}"
+                      keyword (or desc keyword))))))
 
 
-(org-add-link-type
- "scopus-search"
- (lambda (query)
-   (scopus-basic-search query))
- (lambda (query desc format)
-   (let ((url (format
-               "http://www.scopus.com/results/results.url?sort=plf-f&src=s&sot=b&sdt=b&sl=%s&s=TITLE-ABS-KEY%%28%s%%29&origin=searchbasic"
-               (length (url-unhex-string (concat "TITLE-ABS-KEY%28" (url-hexify-string query) "%29")))
-               (url-hexify-string query))))
-     (cond
-      ((eq format 'html)
-       (format "<a href=\"%s\">%s</a>" url (or desc query)))
-      ((eq format 'latex)
-       (format "\\href{%s}{%s}" url (or desc query)))))))
+(org-ref-link-set-parameters "scopus-search"
+  :follow (lambda (query)
+            (scopus-basic-search query))
+  :export (lambda (query desc format)
+            (let ((url (format
+                        "http://www.scopus.com/results/results.url?sort=plf-f&src=s&sot=b&sdt=b&sl=%s&s=TITLE-ABS-KEY%%28%s%%29&origin=searchbasic"
+                        (length (url-unhex-string (concat "TITLE-ABS-KEY%28" (url-hexify-string query) "%29")))
+                        (url-hexify-string query))))
+              (cond
+               ((eq format 'html)
+                (format "<a href=\"%s\">%s</a>" url (or desc query)))
+               ((eq format 'latex)
+                (format "\\href{%s}{%s}" url (or desc query)))))))
 
+(org-ref-link-set-parameters "scopus-advanced-search"
+  :follow (lambda (query)
+            (scopus-advanced-search query))
+  :export (lambda (query desc format)
+            (let ((url (format
+                        "http://www.scopus.com/results/results.url?sort=plf-f&src=s&sot=a&sdt=a&sl=%s&s=%s&origin=searchadvanced"
+                        (length (url-hexify-string query))
+                        (url-hexify-string query))))
+              (cond
+               ((eq format 'html)
+                (format "<a href=\"%s\">%s</a>" url (or desc query)))
+               ((eq format 'latex)
+                (format "\\href{%s}{%s}" url (or desc query)))))))
 
-(org-add-link-type
- "scopus-advanced-search"
- (lambda (query)
-   (scopus-advanced-search query))
- (lambda (query desc format)
-   (let ((url (format
-               "http://www.scopus.com/results/results.url?sort=plf-f&src=s&sot=a&sdt=a&sl=%s&s=%s&origin=searchadvanced"
-               (length (url-hexify-string query))
-               (url-hexify-string query))))
-     (cond
-      ((eq format 'html)
-       (format "<a href=\"%s\">%s</a>" url (or desc query)))
-      ((eq format 'latex)
-       (format "\\href{%s}{%s}" url (or desc query)))))))
-
-
-(org-add-link-type
- "scopusid"
- (lambda
-   (link-string)
-   (browse-url
-    (format
-     "http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s"
-     link-string)))
- (lambda (keyword desc format)
-   (cond
-    ((eq format 'latex)
-     (format "\\href{http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s}{%s}"
-	     keyword (or desc (concat "scopusid:" keyword))))
-    ((eq format 'html)
-     (format "<a href=\"http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s\">%s</a>"
-	     keyword (or desc (concat "scopusid:" keyword)))))))
+(org-ref-link-set-parameters "scopusid"
+  :follow (lambda
+            (link-string)
+            (browse-url
+             (format
+              "http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s"
+              link-string)))
+  :export (lambda (keyword desc format)
+            (cond
+             ((eq format 'latex)
+              (format "\\href{http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s}{%s}"
+                      keyword (or desc (concat "scopusid:" keyword))))
+             ((eq format 'html)
+              (format "<a href=\"http://www.scopus.com/authid/detail.url?origin=AuthorProfile&authorId=%s\">%s</a>"
+                      keyword (or desc (concat "scopusid:" keyword)))))))
 
 
 (provide 'org-ref-scopus)

--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -21,6 +21,7 @@
 ;;; Commentary:
 
 ;;
+(require 'org)
 (require 'org-ref-pdf)  		; for pdftotext-executable
 
 (defvar org-ref-cite-types)
@@ -767,6 +768,13 @@ From the PDF specification 1.7:
                   (insert-file-contents-literally filename nil 0 5)
                   (buffer-string))))
     (string-equal (encode-coding-string header 'utf-8) "%PDF-")))
+
+(defmacro org-ref-link-set-parameters (type &rest parameters)
+  "Set link TYPE properties to PARAMETERS."
+  (declare (indent 1))
+  (if (fboundp 'org-link-set-parameters)
+      `(org-link-set-parameters ,type ,@parameters)
+    `(org-add-link-type ,type ,(plist-get parameters :follow) ,(plist-get parameters :export))))
 
 (provide 'org-ref-utils)
 ;;; org-ref-utils.el ends here

--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -769,6 +769,7 @@ From the PDF specification 1.7:
                   (buffer-string))))
     (string-equal (encode-coding-string header 'utf-8) "%PDF-")))
 
+;;;###autoload
 (defmacro org-ref-link-set-parameters (type &rest parameters)
   "Set link TYPE properties to PARAMETERS."
   (declare (indent 1))

--- a/org-ref-wos.el
+++ b/org-ref-wos.el
@@ -25,42 +25,34 @@
 
 (require 'org)
 (require 's)
+(require 'org-ref-utils)
 
 ;;; Code:
-(org-add-link-type
- "wos"
- (lambda (accession-number)
-   (browse-url
-    (concat
-     "http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/"
-     accession-number)))
- (lambda (accession-number desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/%s\">%s</a>"
-             accession-number
-             (or desc (concat "wos:" accession-number)))))))
+(org-ref-link-set-parameters "wos"
+  :follow (lambda (accession-number)
+            (browse-url
+             (concat
+              "http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/"
+              accession-number)))
+  :export (lambda (accession-number desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&rft_id=info:ut/%s\">%s</a>"
+                      accession-number
+                      (or desc (concat "wos:" accession-number)))))))
 
-
-(org-add-link-type
- "wos-search"
- (lambda (path)
-   (browse-url
-    (format  "http://gateway.webofknowledge.com/gateway/Gateway.cgi?topic=%s&GWVersion=2&SrcApp=WEB&SrcAuth=HSB&DestApp=UA&DestLinkType=GeneralSearchSummary"
-             (s-join
-	      "+"
-	      (split-string path)))))
- ;; formatting function.
- (lambda (link desc format)
-   (cond
-    ((eq format 'html)
-     (format "<a href=\"%s\">%s</a>"
-           (format  "http://gateway.webofknowledge.com/gateway/Gateway.cgi?topic=%s&GWVersion=2&SrcApp=WEB&SrcAuth=HSB&DestApp=UA&DestLinkType=GeneralSearchSummary"
-                    (s-join
-		     "+"
-		     (split-string link)))
-	   (or desc link))))))
-
+(org-ref-link-set-parameters "wos-search"
+  :follow (lambda (path)
+            (browse-url
+             (format  "http://gateway.webofknowledge.com/gateway/Gateway.cgi?topic=%s&GWVersion=2&SrcApp=WEB&SrcAuth=HSB&DestApp=UA&DestLinkType=GeneralSearchSummary"
+                      (s-join "+" (split-string path)))))
+  :export (lambda (link desc format)
+            (cond
+             ((eq format 'html)
+              (format "<a href=\"%s\">%s</a>"
+                      (format  "http://gateway.webofknowledge.com/gateway/Gateway.cgi?topic=%s&GWVersion=2&SrcApp=WEB&SrcAuth=HSB&DestApp=UA&DestLinkType=GeneralSearchSummary"
+                               (s-join "+" (split-string link)))
+                      (or desc link))))))
 
 ;;;###autoload
 (defun wos-search ()


### PR DESCRIPTION
Hi:

I've added a macro `org-ref-link-set-parameters` for compatibility of
`org-link-set-parameters` between Org mode versions, and avoid duplicate code.

The macro in question:

```emacs-lisp
(defmacro org-ref-link-set-parameters (type &rest parameters)
  "Set link TYPE properties to PARAMETERS."
  (declare (indent 1))
  (if (fboundp 'org-link-set-parameters)
      `(org-link-set-parameters ,type ,@parameters)
    `(org-add-link-type ,type ,(plist-get parameters :follow) ,(plist-get parameters :export))))
```
