### PR TITLE
* org-ref-citeproc.el: Fix looking-at function call

### DIFF
--- a/org-ref-citeproc.el
+++ b/org-ref-citeproc.el
@@ -864,7 +864,7 @@ documents."
 		    'chomp-trailing-space
 		    (intern (org-element-property :type link)))
 	       (goto-char end)
-	       (while (looking-at " " (- (point) 2))
+	       (while (looking-back " " (- (point) 2))
 		 (delete-char 1)))
 
 	     ;; Check for transposing punctuation


### PR DESCRIPTION
Checking the code, i think it meant to use `looking-back` instead of `looking-at`

Related #249 