### PR TITLE
Invert command order and suppress minibuffer message in helm

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -1268,7 +1268,15 @@ A number greater than one means multiple labels!"
 ;;** ref link
 (defun org-ref-ref-follow (label)
   "on clicking goto the label. Navigate back with C-c &"
-  (org-mark-ring-push)
+  ;; Suppress minibuffer message in helm. See `org-ref-browser'.
+  (if helm-alive-p
+      (lambda (&optional pos buffer)
+	(setq pos (or pos (point)))
+	(setq org-mark-ring (nthcdr (1- org-mark-ring-length) org-mark-ring))
+	(move-marker (car org-mark-ring)
+		     (or pos (point))
+		     (or buffer (current-buffer))))
+    (org-mark-ring-push))
   ;; next search from beginning of the buffer it is possible you would not find
   ;; the label if narrowing is in effect
   (widen)
@@ -1321,7 +1329,8 @@ A number greater than one means multiple labels!"
     (org-mark-ring-goto)
     (error "%s not found" label))
   (org-show-entry)
-  (message "go back with (org-mark-ring-goto) `C-c &`"))
+  (unless helm-alive-p
+    (message "go back with (org-mark-ring-goto) `C-c &`"))
 
 
 (defun org-ref-complete-link (&optional arg)

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -1267,7 +1267,8 @@ A number greater than one means multiple labels!"
 
 ;;** ref link
 (defun org-ref-ref-follow (label)
-  "on clicking goto the label. Navigate back with C-c &"
+  "On clicking goto the LABEL.
+Navigate back with \`\\[org-mark-ring-goto]'."
   ;; Suppress minibuffer message in helm. See `org-ref-browser'.
   (if helm-alive-p
       (lambda (&optional pos buffer)
@@ -1330,7 +1331,8 @@ A number greater than one means multiple labels!"
     (error "%s not found" label))
   (org-show-entry)
   (unless helm-alive-p
-    (message "go back with (org-mark-ring-goto) `C-c &`"))
+    (substitute-command-keys
+     "Go back with (org-mark-ring-goto) \`\\[org-mark-ring-goto]'.")))
 
 
 (defun org-ref-complete-link (&optional arg)

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -673,51 +673,52 @@ KEY is returned for the selected item(s) in helm."
 
 ;;;###autoload
 (defun org-ref-browser (&optional arg)
-  "Quickly browse citation links.
-With a prefix ARG, browse labels."
+  "Quickly browse label links in helm.
+With a prefix ARG, browse citation links."
   (interactive "P")
   (if arg
-      (helm :sources (org-ref-browser-label-source)
-	    :buffer "*helm labels*")
-    (let ((keys nil)
-	  (alist nil))
-      (widen)
-      (show-all)
-      (org-element-map (org-element-parse-buffer) 'link
-	(lambda (link)
-	  (let ((plist (nth 1 link)))
-	    (when (-contains? org-ref-cite-types (plist-get plist ':type))
-	      (let ((start (org-element-property :begin link)))
-		(dolist (key
-			 (org-ref-split-and-strip-string (plist-get plist ':path)))
-		  (setq keys (append keys (list key)))
-		  (setq alist (append alist (list (cons key start))))))))))
-      (let ((counter 0))
-      	;; the idea here is to create an alist with ("counter key" .
-      	;; position) to produce unique candidates
-      	(setq count-key-pos (mapcar (lambda (x)
-				      (cons
-				       (format "%s %s" (cl-incf counter) (car x)) (cdr x)))
-				    alist)))
-      ;; push mark to restore position with C-u C-SPC
-      (push-mark (point))
-      ;; move point to the first citation link in the buffer
-      (goto-char (cdr (assoc (caar alist) alist)))
-      (helm :sources
-	    (helm-build-sync-source "Browse citation links"
-	      :follow 1
-	      :candidates keys
-	      :candidate-transformer 'org-ref-browser-transformer
-	      :real-to-display 'org-ref-browser-display
-	      :persistent-action (lambda (candidate)
-	      			   (helm-goto-char
-	      			    (cdr (assoc candidate count-key-pos))))
-	      :action `(("Open menu" . ,(lambda (candidate)
-	      				  (helm-goto-char
-	      				   (cdr (assoc candidate count-key-pos)))
-	      				  (org-open-at-point)))))
-	    :candidate-number-limit 10000
-	    :buffer "*helm browser*"))))
+      (let ((keys nil)
+	    (alist nil))
+	(widen)
+	(show-all)
+	(org-element-map (org-element-parse-buffer) 'link
+	  (lambda (link)
+	    (let ((plist (nth 1 link)))
+	      (when (-contains? org-ref-cite-types (plist-get plist ':type))
+		(let ((start (org-element-property :begin link)))
+		  (dolist (key
+			   (org-ref-split-and-strip-string (plist-get plist ':path)))
+		    (setq keys (append keys (list key)))
+		    (setq alist (append alist (list (cons key start))))))))))
+	(let ((counter 0))
+	  ;; the idea here is to create an alist with ("counter key" .
+	  ;; position) to produce unique candidates
+	  (setq count-key-pos (mapcar (lambda (x)
+					(cons
+					 (format "%s %s" (cl-incf counter) (car x)) (cdr x)))
+				      alist)))
+	;; push mark to restore position with C-u C-SPC
+	(push-mark (point))
+	;; move point to the first citation link in the buffer
+	(goto-char (cdr (assoc (caar alist) alist)))
+	(helm :sources
+	      (helm-build-sync-source "Browse citation links"
+		:follow 1
+		:candidates keys
+		:candidate-transformer 'org-ref-browser-transformer
+		:real-to-display 'org-ref-browser-display
+		:persistent-action (lambda (candidate)
+				     (helm-goto-char
+				      (cdr (assoc candidate count-key-pos))))
+		:action `(("Open menu" . ,(lambda (candidate)
+					    (helm-goto-char
+					     (cdr (assoc candidate count-key-pos)))
+					    (org-open-at-point)))))
+	      :candidate-number-limit 10000
+	      :buffer "*helm browser*"))
+    (helm :sources (org-ref-browser-label-source)
+	  :buffer "*helm labels*")))
+
 
 
 (provide 'org-ref-helm-bibtex)


### PR DESCRIPTION
To test with the new code: `M-x org-ref-browser` (or `C-u M-x org-ref-browser` with the old code). I still kept the message when clicking on ref links.