### PR TITLE
add check for http 406 error in doi-utils-get-json-metadata

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -573,7 +573,8 @@ checked."
         (url-retrieve-synchronously
          (concat "http://dx.doi.org/" doi))
       (setq json-data (buffer-substring url-http-end-of-headers (point-max)))
-      (if (string-match "Resource not found" json-data)
+      (if (or (string-match "Resource not found" json-data)
+              (string-match "Status *406" json-data))
           (progn
             (browse-url (concat doi-utils-dx-doi-org-url doi))
             (error "Resource not found.  Opening website"))


### PR DESCRIPTION
I got a json-readtable-error using doi-add-bibtex-entry("10.3233/SW-2012-0069" "~/file.bib").
I seems that some doi providers do not support json and a "HTTP Status 406 - Not Acceptable" error is reported.

The pull request catches this case and opens the website in the browser instead.

Could #377 be related to this?