### PR TITLE
Insert "BibTeX" for easier searching

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -74,7 +74,7 @@
 						    "\n\n"))))
     ("Attach PDF to email" . helm-bibtex-add-PDF-attachment)
     ("Edit notes" . helm-bibtex-edit-notes)
-    ("Show entry" . helm-bibtex-show-entry)
+    ("Show BibTeX entry" . helm-bibtex-show-entry)
     ("Add keywords to entries" . org-ref-helm-tag-entries)
     ("Copy entry to clipboard" . bibtex-completion-copy-candidate) 
     ("Add PDF to library" . helm-bibtex-add-pdf-to-library))


### PR DESCRIPTION
Minor change so that after calling org-ref-helm-insert-cite-link you can find the command to show the bibtex entry by searching "bibtex" in the list of additional actions.