### PR TITLE
Fix typo (missing paren) in manual's suggested elisp

### DIFF
--- a/org-ref.org
+++ b/org-ref.org
@@ -221,7 +221,7 @@ All org-ref links are designed to export to the corresponding LaTeX commands for
       '("pdflatex -interaction nonstopmode -output-directory %o %f"
 	"bibtex %b"
 	"pdflatex -interaction nonstopmode -output-directory %o %f"
-	"pdflatex -interaction nonstopmode -output-directory %o %f")
+	"pdflatex -interaction nonstopmode -output-directory %o %f"))
 #+END_SRC
 
 ** Other exports


### PR DESCRIPTION
Fix missing paren in the manual's example elisp for facilitating LaTeX export

Apologies if there's a standard form for contributed PR's; I couldn't find any suggested workflow