### PR TITLE
Add more options to clean isbn entry

### DIFF
--- a/org-ref-isbn.el
+++ b/org-ref-isbn.el
@@ -158,7 +158,8 @@ in the file. Data comes from worldcat."
     (completing-read
      "Bibfile: "
      (append (f-entries "." (lambda (f) (f-ext? f "bib")))
-             org-ref-default-bibliography))))
+	     ;; Convert relative path to absolute path
+	     (list (file-truename (car org-ref-default-bibliography)))))))
 
   (let* ((results (with-current-buffer
                       (url-retrieve-synchronously


### PR DESCRIPTION
We can exclude fields we don't want
```
(setq org-ref-isbn-exclude-fields '("form" "lang" "lccn" "oclcnum" "url")`
```
And replace field names with something else
```
(setq org-ref-isbn-field-name-replacements '(("ed" . "edition")
					     ("city" . "address")))
```
