### PR TITLE
Fix wrong variable name

### DIFF
--- a/org-ref-isbn.el
+++ b/org-ref-isbn.el
@@ -45,7 +45,7 @@ entry. These functions are wrapped in `save-restriction' and
   :group 'org-ref-isbn
   :type 'hook)
 
-(defcustom org-ref-isbn-kill-fields nil
+(defcustom org-ref-isbn-exclude-fields nil
   "List of bibtex fields to kill when new entry is inserted."
   :group 'org-ref-isbn
   :type '(repeat :tag "List of bibtex fields to kill" string))

--- a/org-ref.org
+++ b/org-ref.org
@@ -465,7 +465,7 @@ This library provides some functions to get bibtex entries for books from their 
 It also provides some variables for customizing the bibtex entry.
 
 - org-ref-isbn-clean-bibtex-entry-hook
-- org-ref-isbn-kill-fields
+- org-ref-isbn-exclude-fields
 - org-ref-isbn-field-name-replacements
 
 ** org-ref-pubmed


### PR DESCRIPTION
I noticed the reference to free variable warning in https://github.com/jkitchin/org-ref/issues/439.

There are more warnings, and errors too.