### PR TITLE
Check whether we know about the journal

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2903,6 +2903,22 @@ If optional NEW-YEAR set it to that, otherwise prompt for it."
     (insert key)
     (kill-new key)))
 
+(defun orcb-check-journal ()
+  "Check entry at point to see if journal exists in `org-ref-bibtex-journal-abbreviations'.
+If not, issue a warning."
+  (interactive)
+  (when
+      (string= "article"
+               (downcase
+                (cdr (assoc "=type=" (bibtex-parse-entry)))))
+    (save-excursion
+      (bibtex-beginning-of-entry)
+      (let* ((entry (bibtex-parse-entry t))
+             (journal (reftex-get-bib-field "journal" entry)))
+        (when (null journal)
+          (error "Unable to get journal for this entry."))
+        (unless (member journal (-flatten org-ref-bibtex-journal-abbreviations))
+          (message "Journal \"%s\" not found in org-ref-bibtex-journal-abbreviations." journal))))))
 
 ;;;###autoload
 (defun org-ref-clean-bibtex-entry ()

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -430,6 +430,7 @@ http://ctan.mirrorcatalogs.com/macros/latex/contrib/biblatex/doc/biblatex.pdf"
     orcb-key
     orcb-clean-doi
     orcb-clean-pages
+    orcb-check-journal
     org-ref-sort-bibtex-entry)
   "Hook that is run in `org-ref-clean-bibtex-entry'.
 The functions should have no arguments, and


### PR DESCRIPTION
This is the function I mentioned in #460 . It checks whether we know about the journal in bibtex entries. It doesn't prompt the user or anything - it just issues a message if the journal isn't there.

I also added it to the list of functions in org-ref-clean-bibtex-entry-hook. If you prefer, I can leave it out of there, though.