### PR TITLE
Add pdf to bibtex

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -1317,6 +1317,15 @@ will clobber the file."
     (with-temp-file bibfile
       (insert contents))))
 
+(defun org-ref-bibtex-key-from-doi (doi &optional bib)
+  "Return a bib entry's key from a doi."
+  (let ((bibfile (if bib bib (car org-ref-default-bibliography))))
+    (with-temp-buffer
+      (insert-file-contents (expand-file-name bibfile))
+      (search-forward doi)
+      (bibtex-beginning-of-entry)
+      (cdr (assoc "=key=" (bibtex-parse-entry))))))
+
 ;;* The end
 (provide 'org-ref-bibtex)
 

--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -33,6 +33,8 @@
 (eval-when-compile
   (require 'cl))
 
+(declare-function org-ref-bibtex-key-from-doi "org-ref-bibtex.el")
+
 (defgroup org-ref-pdf nil
   "Customization group for org-ref-pdf"
   :tag "Org Ref PDF"
@@ -102,6 +104,25 @@ Used when multiple dois are found in a pdf file."
 	    doi
 	    (buffer-file-name))))
 
+;;;###autoload
+(defun org-ref-pdf-to-bibtex ()
+  "Add pdf of current buffer to bib file and save pdf to `org-ref-default-bibliography'."
+  (interactive)
+  (when (not (f-ext? (buffer-file-name) "pdf"))
+    (error "Buffer is not a pdf file"))
+  ;; Get doi from pdf of current buffer
+  (let* ((dois (org-ref-extract-doi-from-pdf (buffer-file-name)))
+         (doi-utils-download-pdf nil)
+         (doi (if (= 1 (length dois))
+                  (car dois)
+                (completing-read "Select DOI: " dois))))
+    ;; Add bib entry from doi:
+    (doi-utils-add-bibtex-entry-from-doi doi)
+    ;; Copy pdf to `org-ref-pdf-directory':
+    (let ((key (org-ref-bibtex-key-from-doi doi)))
+      (copy-file (buffer-file-name)
+                 (expand-file-name (format "%s.pdf" key)
+                                   org-ref-pdf-directory)))))
 
 ;;;###autoload
 ;; (defun org-ref-pdf-dnd-func (event)

--- a/org-ref.org
+++ b/org-ref.org
@@ -631,7 +631,10 @@ This provides some org-ref like capabilities in LaTeX files, e.g. the links are 
 
 ** org-ref-pdf
 
-Allows you to drag and drop a PDF onto a bibtex file to add a bibtex entry (as long as you have pdftotext, and the pdf has an identifiable DOI in it.) This library is known to not work on Windows very well.
+=org-ref-pdf= allows Emacs to get bibliography information from pdf files that contain a DOI. You must have =pdftotext= installed where Emacs can find it. This library is known to not work on Windows very well.
+
+- Drag and drop a PDF onto a bibtex file to add a bibtex entry
+- If you have a pdf file open (from, for example, an email attachment), use ~org-ref-pdf-to-bibtex~ to write the bibliography information to a bib file, (defaulting to ~org-ref-default-bibliography~) and save the pdf to ~org-ref-pdf-directory~.
 
 ** org-ref-url-utils
 


### PR DESCRIPTION
This adds a function that gets the doi from the pdf file currently open, adds into from the doi to the bibfile, and then copies that file to the pdf folder.