### PR TITLE
Generalized title-case conversion for entries

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -34,7 +34,7 @@
 ;; org-ref-set-journal-string :: in a bibtex entry run this to replace the
 ;; journal with a string
 ;;
-;; org-ref-title-case-article :: title case the title in an article
+;; org-ref-title-case-article :: title case the title in an article or book
 ;; org-ref-sentence-case-article :: sentence case the title in an article.
 
 ;; org-ref-replace-nonascii :: replace nonascii characters in a bibtex
@@ -456,13 +456,19 @@ This is defined in `org-ref-bibtex-journal-abbreviations'."
     "the" "of" "in")
   "List of words to keep lowercase when changing case in a title.")
 
+(defcustom org-ref-title-case-types '("article" "book")
+  "List of bibtex entry types in which the title will be converted to
+title-case by org-ref-title-case."
+  :type '(repeat string)
+  :group 'org-ref-bibtex)
 
 ;;;###autoload
-(defun org-ref-title-case-article (&optional key start end)
-  "Convert a bibtex entry article title to title-case.
-The arguments KEY, START and END are optional, and are only there
-so you can use this function with `bibtex-map-entries' to change
-all the title entries in articles."
+(defun org-ref-title-case (&optional key start end)
+  "Convert a bibtex entry title to title-case if the entry type
+is a member of the list org-ref-title-case-types. The arguments
+KEY, START and END are optional, and are only there so you can
+use this function with `bibtex-map-entries' to change all the
+title entries in articles and books."
   (interactive)
   (bibtex-beginning-of-entry)
 
@@ -470,9 +476,9 @@ all the title entries in articles."
          (words (split-string title))
          (start 0))
     (when
-        (string= "article"
-		 (downcase
-		  (cdr (assoc "=type=" (bibtex-parse-entry)))))
+        (member (downcase
+		 (cdr (assoc "=type=" (bibtex-parse-entry))))
+		org-ref-title-case-types)
       (setq words (mapcar
                    (lambda (word)
 		     (cond
@@ -518,6 +524,16 @@ all the title entries in articles."
        "title"
        title)
       (bibtex-fill-entry))))
+
+;;;###autoload
+(defun org-ref-title-case-article (&optional key start end)
+  "Convert a bibtex entry article or book title to title-case.
+The arguments KEY, START and END are optional, and are only there
+so you can use this function with `bibtex-map-entries' to change
+all the title entries in articles and books."
+  (interactive)
+  (let ((org-ref-title-case-types '("article")))
+    (org-ref-title-case)))
 
 
 ;;;###autoload
@@ -672,12 +688,12 @@ there is a DOI."
 (defun org-ref-bibtex-google-scholar ()
   "Open the bibtex entry at point in google-scholar by its doi."
   (interactive)
-  (let ((doi (org-ref-bibtex-entry-doi))) 
+  (let ((doi (org-ref-bibtex-entry-doi)))
     (doi-utils-google-scholar
      (if (string= "" doi)
 	 (save-excursion
 	   (bibtex-beginning-of-entry)
-	   (reftex-get-bib-field "title" (bibtex-parse-entry t))) 
+	   (reftex-get-bib-field "title" (bibtex-parse-entry t)))
        doi))))
 
 
@@ -1239,7 +1255,7 @@ of format strings used."
 
 (defun org-ref-format-entry (key)
   "Returns a formatted bibtex entry for KEY."
-  (let* ((bibtex-completion-bibliography (org-ref-find-bibliography))) 
+  (let* ((bibtex-completion-bibliography (org-ref-find-bibliography)))
     (org-ref-format-bibtex-entry (ignore-errors (bibtex-completion-get-entry key)))))
 
 

--- a/org-ref.org
+++ b/org-ref.org
@@ -163,13 +163,13 @@ A ref link refers to a label of some sort. For example, you can refer to a table
 | 1 |
 | 2 |
 
-Or you can refer to an org-mode label as in Table ref:table-3. 
+Or you can refer to an org-mode label as in Table ref:table-3.
 
 
 Note: You may need to set org-latex-prefer-user-labels to t if you refer to times by their "name" for the export to use the name you create.
 
 #+BEGIN_SRC emacs-lisp
-(setq org-latex-prefer-user-labels t) 
+(setq org-latex-prefer-user-labels t)
 #+END_SRC
 
 #+RESULTS:
@@ -267,7 +267,7 @@ The command ~org-ref~ does a lot for you automatically. It will check the buffer
 7. runs your hook functions
 8. sorts the fields in the entry
 9. checks the buffer for non-ascii characters
-10. converts article title to title case
+10. converts article title to title case (note: see below to convert titles in other entry types)
 
 This function has a hook ~org-ref-clean-bibtex-entry-hook~, which you can add functions to of your own. Each function must work on a bibtex entry at point.
 
@@ -303,7 +303,7 @@ There is some basic support for HTML and ascii export. Not all bibtex entry type
 
 * org-ref-ivy
 
-org-ref provides an alternative to reftex and helm with ivy as the backend completion engine for searching and entering citations. 
+org-ref provides an alternative to reftex and helm with ivy as the backend completion engine for searching and entering citations.
 
 You can set this backend in your init file like this
 #+BEGIN_SRC emacs-lisp
@@ -380,7 +380,7 @@ curl -LH "Accept: application/citeproc+json" "http://doi.org/10.1021/jp511426q"
 
 If you do not get json data, doi-utils will not be able to generate the bibtex entry.
 
-Not all PDFs can be retrieved. doi-utils uses a set of functions to attempt this. Here is the list. 
+Not all PDFs can be retrieved. doi-utils uses a set of functions to attempt this. Here is the list.
 
 #+BEGIN_SRC emacs-lisp
 doi-utils-pdf-url-functions
@@ -422,6 +422,7 @@ The variable ~org-ref-bibtex-journal-abbreviations~ contains a mapping of a shor
      with a string selected interactively.
 
 - org-ref-title-case-article :: title case the title in an article entry.
+- org-ref-title-case :: title case the title for entries listed in `org-ref-title-case-types'.
 - org-ref-sentence-case-article :: sentence case the title in an article entry.
 
 - org-ref-replace-nonascii :: replace nonascii characters in a bibtex
@@ -471,7 +472,7 @@ Or this if you like key-chord:
 
 org-ref has some limited capability to make formatted bibliography entries from a bibtex entry or citation link. This is generally a hard problem, and the first solution is not a replacement for a dedicated citation processor like BibTeX. Two variable determine the behavior of formatted citations:
 
-- Formats are from `org-ref-formatted-citation-formats' is an a-list of (backend . formats). formats is an alist of (entry-type . format-string). 
+- Formats are from `org-ref-formatted-citation-formats' is an a-list of (backend . formats). formats is an alist of (entry-type . format-string).
 - The variable `org-ref-formatted-citation-backend' determines which set of format strings is used. The default is "text", and "org" format strings are also defined.
 
 So, if you click on a citation link, there should be a menu option to copy a formatted citation, which will copy the citation string to the clipboard.
@@ -666,7 +667,7 @@ You can also specify different completion backends. The default is `org-ref-helm
 - org-ref-reftex :: A backend that uses reftex
 - org-ref-helm-cite :: An alternative helm completion backend (does not use helm-bibtex)
 - org-ref-ivy-cite :: uses ivy for the backend
- 
+
 To use one of these, add a line like this before you "require" org-ref.
 
 #+BEGIN_SRC emacs-lisp

--- a/test/all-org-test.org
+++ b/test/all-org-test.org
@@ -150,7 +150,7 @@ Getting the language
 : emacs-lisp
 
 The body
-#+BEGIN_SRC emacs-lisp 
+#+BEGIN_SRC emacs-lisp
 (nth 1 (org-babel-get-src-block-info))
 #+END_SRC
 
@@ -176,8 +176,8 @@ Name
 
 #+RESULTS:
 
-Is it a test? If this returns non-nil, 
-#+BEGIN_SRC emacs-lisp 
+Is it a test? If this returns non-nil,
+#+BEGIN_SRC emacs-lisp
 (and (assoc :test (nth 2 (org-babel-get-src-block-info)))
      (not (string= "ignore" (cdr (assoc :test (nth 2 (org-babel-get-src-block-info)))))))
 #+END_SRC
@@ -519,7 +519,7 @@ label:one
   (expand-file-name
    "tests/bibtex-pdfs/kitchin-2015.pdf"
    (file-name-directory
-    (locate-library "org-ref"))) 
+    (locate-library "org-ref")))
   (org-test-with-temp-text
       "cite:kitchin-2015"
     (let ((org-ref-pdf-directory (expand-file-name
@@ -763,7 +763,7 @@ label:one
 			  (expand-file-name
 			   "tests/test-1.bib"
 			   (file-name-directory
-			    (locate-library "org-ref"))))	      
+			    (locate-library "org-ref"))))
 	      (org-ref-find-bibliography)))))
 #+END_SRC
 
@@ -801,7 +801,7 @@ label:one
 	      (expand-file-name
 	       "tests/test-2.bib"
 	       (file-name-directory
-		(locate-library "org-ref"))))	      
+		(locate-library "org-ref"))))
     (org-ref-find-bibliography))))
 #+END_SRC
 
@@ -924,7 +924,7 @@ bibliography:%s
 #+name: short-titles
 #+BEGIN_SRC emacs-lisp :test
 (org-ref-bibtex-generate-shorttitles)
-(prog1 
+(prog1
     (should
      (file-exists-p "shorttitles.bib"))
   (delete-file "shorttitles.bib"))
@@ -1062,6 +1062,29 @@ bibliography:%s
 #+RESULTS: title-case-3
 : t
 
+#+name: title-case-4
+#+BEGIN_SRC emacs-lisp :test
+(should (string=
+	   "An Example of Effective Data-Sharing"
+	   (with-temp-buffer
+	     (bibtex-mode)
+	     (bibtex-set-dialect (parsebib-find-bibtex-dialect) t)
+	     (insert "@thesis{kitchin-2015-examp,
+  author =	 {Kitchin, John R.},
+  title =	 {An example of effective data-sharing},
+  publisher = {Awesome Publishing},
+  year =	 2015,
+  keywords =	 {DESC0004031, early-career, orgmode, Data sharing },
+}")
+	     (goto-char (point-min))
+	     (let ((org-ref-title-case-types '("article" "book")))
+	       (org-ref-title-case))
+(bibtex-autokey-get-field "title"))))
+#+END_SRC
+
+#+RESULTS: title-case-4
+: t
+
 
 
 
@@ -1176,7 +1199,7 @@ bibliography:%s
 
 
 
-** next/previous bibtex entries 
+** next/previous bibtex entries
 #+name: next-entry-1
 #+BEGIN_SRC emacs-lisp :test
 (should
@@ -1818,7 +1841,7 @@ the in the past.
 ** subsection \\label{three}
   :PROPERTIES:
   :CUSTOM_ID: two
-  :END: 
+  :END:
 
 label:four
 "
@@ -2332,7 +2355,7 @@ bibliography:%s
 "
 	   (expand-file-name
 	    "tests/test-1.bib"
-	    (file-name-directory (locate-library "org-ref")))) 
+	    (file-name-directory (locate-library "org-ref"))))
 	  (org-test-with-temp-text
 	      (format
 	       "cite:kitchin-2008-alloy,kitchin-2004-role
@@ -2789,7 +2812,7 @@ bibliography:%s
 			     "org-ref"))))))
    (string= "/Users/jkitchin/Dropbox/bibliography/bibtex-pdfs/abild-pedersen-2007-scalin-proper.pdf"
 	    (org-test-with-temp-text
-		bibstring	      
+		bibstring
 	      ""
 	      (org-ref-get-mendeley-filename "Abild-Pedersen2007")))))
 #+END_SRC
@@ -2832,10 +2855,10 @@ bibliography:tests/test-1.bib
 
 
 
- cite:kitchin-2015-examp   
+ cite:kitchin-2015-examp
 
 
- 
+
 #+name: cite-face-1
 #+BEGIN_SRC emacs-lisp :test
 (org-test-with-temp-text
@@ -2851,7 +2874,7 @@ bibliography:tests/test-1.bib
        (org-ref-match-next-ref-link (0  'org-ref-ref-face t))
        (org-ref-match-next-bibliography-link (0  'org-link t))
        (org-ref-match-next-bibliographystyle-link (0  'org-link t)))
-     t)) 
+     t))
   (org-mode)
   (font-lock-fontify-region (point-min) (point-max))
   (describe-text-properties 1)
@@ -2875,7 +2898,7 @@ bibliography:tests/test-1.bib
     (font-lock-add-keywords
      nil
      '((org-ref-match-next-cite-link (0  'org-ref-cite-face t)))
-     t)) 
+     t))
   (font-lock-fontify-region (point-min) (point-max))
   (should (not (eq 'org-ref-cite-face (get-char-property 5 'face)))))
 #+END_SRC
@@ -3081,7 +3104,7 @@ cite
 
 * Store link tests
 
-org-store-link-plist 
+org-store-link-plist
 #+name: store-label-link
 #+BEGIN_SRC emacs-lisp :test
 (org-test-with-temp-text


### PR DESCRIPTION
I wanted to title-case books as well. This was discussed a bit without resolution in #404, so I would like to propose a general function that can be configured to work on designated types.

This change provides a new function, org-ref-title-case, that uses the
customizable variable org-ref-title-case-types to specify what entry
types can have titles converted to title-case.

org-ref-title-case-article works exactly the same as before, but calls
org-ref-title-case with a type list limited to "article" to do the work.

Added brief notes to documentation about the changes.

Added simple test case for the changes.