### PR TITLE
org-ref-sort-bibtex-entry: downcase the entry type when looking up the field order for sorting.

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2758,7 +2758,7 @@ file.  Makes a new buffer with clickable links."
          (other-fields)
          (type (cdr (assoc "=type=" entry)))
          (key (cdr (assoc "=key=" entry)))
-	 (field-order (cdr (assoc (if type (downcase-type))
+	 (field-order (cdr (assoc (if type (downcase type))
 				  org-ref-bibtex-sort-order))))
 
     ;; these are the fields we want to order that are in this entry

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2758,7 +2758,8 @@ file.  Makes a new buffer with clickable links."
          (other-fields)
          (type (cdr (assoc "=type=" entry)))
          (key (cdr (assoc "=key=" entry)))
-	 (field-order (cdr (assoc type org-ref-bibtex-sort-order))))
+	 (field-order (cdr (assoc (if type (downcase-type))
+				  org-ref-bibtex-sort-order))))
 
     ;; these are the fields we want to order that are in this entry
     (setq entry-fields (mapcar (lambda (x) (car x)) entry))


### PR DESCRIPTION
Before this change, the code would not sort fields correctly if the
entry type was capitalized (e.g., "@Article"). BibTeX doesn't care
about the capitalization, so some entries are like that.