### PR TITLE
Removed the check of the whole buffer in org-ref-replace-ascii.

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -446,9 +446,7 @@ This is defined in `org-ref-bibtex-journal-abbreviations'."
 			  org-ref-nonascii-latex-replacements))
       (while (re-search-forward char nil t)
         (replace-match (cdr (assoc char org-ref-nonascii-latex-replacements))))
-      (goto-char (point-min))))
-  (occur "[^[:ascii:]]"))
-
+      (goto-char (point-min)))))
 
 ;;* Title case transformations
 (defvar org-ref-lower-case-words
@@ -1064,7 +1062,7 @@ the cache."
 	  collect
 	  (string= (with-temp-buffer
 		     (insert-file-contents bibfile)
-		     (secure-hash 'sha256 (current-buffer))) 
+		     (secure-hash 'sha256 (current-buffer)))
 		   (or (cdr (assoc
 			     bibfile
 			     (cdr (assoc 'hashes orhc-bibtex-cache-data)))) "")))))
@@ -1195,7 +1193,7 @@ Files that have the same hash as in the cache are not updated."
   (cl-loop for bibfile in org-ref-bibtex-files
 	   unless (string= (with-temp-buffer
 			     (insert-file-contents bibfile)
-			     (secure-hash 'sha256 (current-buffer))) 
+			     (secure-hash 'sha256 (current-buffer)))
 			   (or (cdr
 				(assoc bibfile
 				       (cdr

--- a/org-ref.org
+++ b/org-ref.org
@@ -256,7 +256,7 @@ We change the order of the actions in helm-bibtex to suit our work flow, and add
 
 The command ~org-ref~ does a lot for you automatically. It will check the buffer for errors, e.g. multiply-defined labels, bad citations or ref links, and provide easy access to a few commands through a helm buffer.
 
-~org-ref-clean-bibtex-entry~ will sort the fields of a bibtex entry, clean it, and give it a bibtex key. This function does a lot of cleaning:
+~org-ref-clean-bibtex-entry~ will sort the fields of a bibtex entry, clean it, and give it a bibtex key. By default, this function does a lot of cleaning:
 
 1. adds a comma if needed in the first line of the entry
 2. makes sure the DOI field is an actual DOI, and not a URL
@@ -266,10 +266,10 @@ The command ~org-ref~ does a lot for you automatically. It will check the buffer
 6. generate a key according to your setup
 7. runs your hook functions
 8. sorts the fields in the entry
-9. checks the buffer for non-ascii characters
+9. checks the entry for non-ascii characters
 10. converts article title to title case (note: see below to convert titles in other entry types)
 
-This function has a hook ~org-ref-clean-bibtex-entry-hook~, which you can add functions to of your own. Each function must work on a bibtex entry at point.
+This function has a hook ~org-ref-clean-bibtex-entry-hook~, which you can add functions to of your own. Each function must work on a bibtex entry at point. (Note: the default behavior can be changed by removing the relevant functions from the initial value of ~org-ref-clean-bibtex-entry-hook~.)
 
 #+BEGIN_SRC emacs-lisp
 (add-hook 'org-ref-clean-bibtex-entry-hook 'org-ref-replace-nonascii)


### PR DESCRIPTION
[Just noticed in a final review: a few trailing whitespace characters were deleted by delete-trailing-whitespace, which I have on before-save-hook in my Emacs config. I'd be happy to redo the pull request without that if you want.]

The function org-ref-non-ascii-characters can still be used to check
the whole buffer if desired.

Modified the documentation to note that the org-ref-replace-ascii only
changes the current entry.

Added a note in the documentation about how the default behavior of
org-ref-clean-bibtex-entry can be changed by changing the initial list
of functions on the hook.