### PR TITLE
Add support for paper-conference in doi-utils

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -718,7 +718,7 @@ MATCHING-TYPES."
 (doi-utils-def-bibtex-type article ("journal-article" "article-journal")
                            author title journal year volume number pages doi url)
 
-(doi-utils-def-bibtex-type inproceedings ("proceedings-article")
+(doi-utils-def-bibtex-type inproceedings ("proceedings-article" "paper-conference")
                            author title booktitle year month pages doi url)
 
 (doi-utils-def-bibtex-type book ("book")


### PR DESCRIPTION
It seems as though the doi type for some papers published in IEEE Symposiums is set to "paper-conference" instead of "proceedings-article".

As far as I checked there is no difference between them, therefore I propose adding the type to the bibtex-type definition in doi-utils.

This should fix at least a part of #495 .