### PR TITLE
[WIP] Update testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ matrix:
 script:
   - emacs --version
   - EMACS=`evm bin` make test
+  - EMACS=`evm bin` make compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26-pretest-travis
   - EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 matrix:
   allow_failures:
+  - env: EVM_EMACS=emacs-26-pretest-travis
   - env: EVM_EMACS=emacs-git-snapshot-travis
   
 script:

--- a/Cask
+++ b/Cask
@@ -5,6 +5,7 @@
 (package-file "org-ref.el")
 
 (development
+ (depends-on "s")
  (depends-on "org-plus-contrib")
  (depends-on "ecukes")
  (depends-on "ert-runner")

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ orgtest:
 mytest: orgtest
 	${CASK_EXEC} ${emacs} -Q -batch  -l ${INIT}  -l test/org-test-setup.el -l test/*-test.el -f ert-run-tests-batch-and-exit
 
-compile:
-	${CASK_EXEC} ${emacs} -Q -batch -l ${INIT} --eval "(setq byte-compile-error-on-warn t)"-L "." -f batch-byte-compile *.el
+compile: ${EL_SOURCES}
+	${CASK_EXEC} ${emacs} -Q -batch -l ${INIT} --eval "(setq byte-compile-error-on-warn t)" -L "." -f batch-byte-compile $<
 
 clean:
 	rm -f *.elc

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ mytest: orgtest
 	${CASK_EXEC} ${emacs} -Q -batch  -l ${INIT}  -l test/org-test-setup.el -l test/*-test.el -f ert-run-tests-batch-and-exit
 
 compile:
-	${CASK_EXEC} ${emacs} -Q -batch -l ${INIT} -L "." -f batch-byte-compile *.el
+	${CASK_EXEC} ${emacs} -Q -batch -l ${INIT} --eval "(setq byte-compile-error-on-warn t)"-L "." -f batch-byte-compile *.el
 
 clean:
 	rm -f *.elc

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ orgtest:
 mytest: orgtest
 	${CASK_EXEC} ${emacs} -Q -batch  -l ${INIT}  -l test/org-test-setup.el -l test/*-test.el -f ert-run-tests-batch-and-exit
 
-compile: ${EL_SOURCES}
-	${CASK_EXEC} ${emacs} -Q -batch -l ${INIT} --eval "(setq byte-compile-error-on-warn t)" -L "." -f batch-byte-compile $<
+compile:
+	${CASK} build
 
 clean:
 	rm -f *.elc


### PR DESCRIPTION
This updates the testing environment to check with Emacs 25.3 and the 26 pretest. It also adds a test that ensures org-ref compiles without warnings (which will fail as of the moment, I believe)