### PR TITLE
Integrate kpsewhich, fixes

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -904,15 +904,10 @@ we open it, otherwise prompt for which one to open."
 
 (defun org-ref-find-bibfile (bibfile)
   "Find BIBFILE as local file, or using kpsewhich or bibinputs."
-  (let* ((local-file (if (file-exists-p bibfile) bibfile))
-	 (kpsew-file (if local-file
-			 local-file
-		       (org-ref-bibfile-kpsewhich bibfile)))
-	 ;; this should never be reached because kpsewhich is stronger
-	 (final-file (if kpsew-file kpsew-file
-		       (org-ref-locate-file bibfile
-					    (org-ref-bibinputs)))))
-    final-file))
+  (or (if (file-exists-p bibfile) bibfile)
+      (org-ref-bibfile-kpsewhich bibfile)
+      ;; this should never be reached because kpsewhich is stronger
+      (org-ref-locate-file bibfile (org-ref-bibinputs))))
 
 
 (defun org-ref-locate-file (filename path)

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -903,7 +903,7 @@ we open it, otherwise prompt for which one to open."
 
 
 (defun org-ref-find-bibfile (bibfile)
-  "Try to find BIBFILE as local file, kpsewhich, using bibinputs."
+  "Find BIBFILE as local file, or using kpsewhich or bibinputs."
   (let* ((local-file (if (file-exists-p bibfile) bibfile))
 	 (kpsew-file (if local-file
 			 local-file


### PR DESCRIPTION
Thank you very much for your integration of `kpsewhich`.  They did not completely work for me.  The following solves #533 for me by adding a function `org-ref-find-bibfile`.

I suppose you could drop the BIBINPUTS processing now, because it will not be reached if `kpsewhich` works – I kept your order of processing –, and is less compatible with what TeX does, anyway.

Also, I did not understand what the `do-list` in `org-ref-link-message` did, so I fixed(?) it.

Cheers!