### PR TITLE
Prefer cl-lib to cl

### DIFF
--- a/citeproc/readme.org
+++ b/citeproc/readme.org
@@ -180,7 +180,7 @@ Dealing with these brackets is somewhat tricky. We cannot simply split on spaces
 
 Here are examples of case 1.
 #+BEGIN_SRC emacs-lisp
-(loop for author in '("John R. Kitchin"
+(cl-loop for author in '("John R. Kitchin"
                       "John von Kitchin"
                       "John von de La von Kitchin"
                       "John von de Kitchin Jr."
@@ -213,7 +213,7 @@ Here are examples of case 1.
 
 Case 2.
 #+BEGIN_SRC emacs-lisp
-(loop for author in '("von Beethoven, Ludwig"
+(cl-loop for author in '("von Beethoven, Ludwig"
                       "{van {M}ieghem}, Jan A."
                       "De Gaulle, Charles"
                       "Van Buren, Martin"
@@ -240,7 +240,7 @@ Case 2.
 
 And case 3
 #+BEGIN_SRC emacs-lisp
-(loop for author in '("von de la Kitchin, Sr., John Robert"
+(cl-loop for author in '("von de la Kitchin, Sr., John Robert"
                       "von Kitchin, Sr., John Robert")
       collect (citeproc-parse-authorname author))
 #+END_SRC
@@ -254,7 +254,7 @@ I am pretty satisfied with that. This is a foundation for formatting author name
 
 From http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names
 #+BEGIN_SRC emacs-lisp
-(loop for author in '("Aa Bb"
+(cl-loop for author in '("Aa Bb"
                       "Aa"
                       "Aa bb"
                       "aa"
@@ -1467,7 +1467,7 @@ citeyear:wang-2013-immob-co2
 : Antony, Abbin; Asthagiri, Aravind and Weaver, Jason F., /Pathways for {C-H} Bond Cleavage of Propane $\sigma$-complexes on {PdO}(101)/, Phys. Chem. Chem. Phys., 14*(35)*, pp. 12202 (2012).doi:10.1039/c2cp41900a.
 
 #+BEGIN_SRC emacs-lisp
-(mapconcat 'identity (loop for entry in (orcp-collect-unique-entries)
+(mapconcat 'identity (cl-loop for entry in (orcp-collect-unique-entries)
                            collect
                            (concat
                             (orcp-author entry)
@@ -1585,7 +1585,7 @@ You run these to get the replacements
 #+END_SRC
 
 #+BEGIN_SRC emacs-lisp
-(loop for link in *orcp-citation-links*
+(cl-loop for link in *orcp-citation-links*
       for repl in (orcp-get-citation-replacements)
       collect
       (list repl
@@ -1664,7 +1664,7 @@ You run these to get the replacements
 
 
 #+BEGIN_SRC emacs-lisp
-(loop for link in (org-element-map
+(cl-loop for link in (org-element-map
                         (org-element-parse-buffer) 'link 'identity)
         if (string= "bibliographystyle"
                     (org-element-property :type link))

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -45,10 +45,11 @@
 (declare-function org-ref-find-bibliography "org-ref-core")
 (declare-function org-ref-clean-bibtex-entry "org-ref-core")
 (declare-function reftex-get-bib-field "reftex-cite")
+(declare-function bibtex-completion-edit-notes "bibtex-completion")
 
-(require 'bibtex)
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
+(require 'bibtex)
 (require 'dash)
 (require 'json)
 (require 'org)                          ; org-add-link-type

--- a/org-ref-glossary.el
+++ b/org-ref-glossary.el
@@ -108,10 +108,10 @@ there is an escaped \" for example. This seems pretty robust."
       (forward-char)
       (when (and (looking-at "{")
 		 (not (looking-back "\\\\" (- (point) 2))))
-	(incf level))
+	(cl-incf level))
       (when (and (looking-at "}")
 		 (not (looking-back "\\\\" (- (point) 2))))
-	(decf level)))
+	(cl-decf level)))
     (point)))
 
 

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -70,8 +70,8 @@
     ("Insert formatted citation(s)" . (lambda (_)
 					(insert
 					 (mapconcat 'identity
-						    (loop for key in (helm-marked-candidates)
-							  collect (org-ref-format-entry key))
+						    (cl-loop for key in (helm-marked-candidates)
+							     collect (org-ref-format-entry key))
 						    "\n\n"))))
     ("Attach PDF to email" . helm-bibtex-add-PDF-attachment)
     ("Edit notes" . helm-bibtex-edit-notes)

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -278,14 +278,14 @@ SOURCE is ignored, but required."
 		   ("Insert formatted entries" . (lambda (_)
 						   (insert
 						    (mapconcat 'identity
-							       (loop for key in (helm-marked-candidates)
-								     collect (org-ref-format-entry key))
+							       (cl-loop for key in (helm-marked-candidates)
+								        collect (org-ref-format-entry key))
 							       "\n\n"))))
 		   ("Copy formatted entry" . (lambda (_)
 					       (kill-new
 						(mapconcat 'identity
-							   (loop for key in (helm-marked-candidates)
-								 collect (org-ref-format-entry key))
+							   (cl-loop for key in (helm-marked-candidates)
+								    collect (org-ref-format-entry key))
 							   "\n\n")))))))
 
   ;; this is where we could add WOK/scopus functions

--- a/org-ref-helm.el
+++ b/org-ref-helm.el
@@ -322,12 +322,12 @@ at the end of you file.
 	      (cl-pushnew (cons (match-string-no-properties 1) (point)) matches)))
 
 	  ;; #+tblname: and actually #+label
-	  (loop for cell in (org-element-map (org-element-parse-buffer 'element) 'table
-			      (lambda (table)
-				(cons (org-element-property :name table)
-				      (org-element-property :begin table))))
-		do
-		(cl-pushnew cell matches))
+	  (cl-loop for cell in (org-element-map (org-element-parse-buffer 'element) 'table
+			         (lambda (table)
+				   (cons (org-element-property :name table)
+				         (org-element-property :begin table))))
+		   do
+		   (cl-pushnew cell matches))
 
 	  ;; CUSTOM_IDs
 	  (org-map-entries
@@ -352,12 +352,12 @@ at the end of you file.
 				    (string= "cref" (org-element-property :type el))
 				    (string= "Cref" (org-element-property :type el)))
 			    (org-element-property :path el))))))
-	    (loop for (label . p) in matches 
-		  do
-		  (when (not (-contains? refs label))
-		    (cl-pushnew
-		     (cons label (set-marker (make-marker) p))
-		     unreferenced-labels)))))))
+	    (cl-loop for (label . p) in matches
+		     do
+		     (when (not (-contains? refs label))
+		       (cl-pushnew
+		        (cons label (set-marker (make-marker) p))
+		        unreferenced-labels)))))))
 
 
     (helm :sources `(((name . "Bad citations")

--- a/org-ref-ivy-cite.el
+++ b/org-ref-ivy-cite.el
@@ -83,17 +83,17 @@
 If `org-ref-ivy-cite-marked-candidates' is non-nil then they are added instead of ENTRY.
 ENTRY is selected from `orhc-bibtex-candidates'."
   (with-ivy-window
-    (if org-ref-ivy-cite-marked-candidates
-	(loop for entry in org-ref-ivy-cite-marked-candidates
-	      do
-	      (if ivy-current-prefix-arg
-		  (let ((org-ref-default-citation-link (ivy-read "Type: " org-ref-cite-types)))
-		    (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry)))))
-		(org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry))))))
-      (if ivy-current-prefix-arg
-	  (let ((org-ref-default-citation-link (ivy-read "Type: " org-ref-cite-types)))
-	    (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry)))))
-	(org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry))))))))
+   (if org-ref-ivy-cite-marked-candidates
+       (cl-loop for entry in org-ref-ivy-cite-marked-candidates
+	        do
+	        (if ivy-current-prefix-arg
+		    (let ((org-ref-default-citation-link (ivy-read "Type: " org-ref-cite-types)))
+		      (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry)))))
+		  (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry))))))
+     (if ivy-current-prefix-arg
+	 (let ((org-ref-default-citation-link (ivy-read "Type: " org-ref-cite-types)))
+	   (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry)))))
+       (org-ref-insert-key-at-point (list (cdr (assoc "=key=" entry))))))))
 
 
 (defun or-ivy-bibtex-open-pdf (entry)
@@ -208,11 +208,11 @@ This uses a citeproc library."
 (defun or-ivy-bibtex-insert-formatted-citation (_)
   "Insert formatted citations at point for selected entries."
   (with-ivy-window
-    (insert (mapconcat
-	     'identity
-	     (loop for entry in org-ref-ivy-cite-marked-candidates
-		   collect (org-ref-format-bibtex-entry entry))
-	     "\n\n"))))
+   (insert (mapconcat
+	    'identity
+	    (cl-loop for entry in org-ref-ivy-cite-marked-candidates
+		     collect (org-ref-format-bibtex-entry entry))
+	    "\n\n"))))
 
 
 (defun or-ivy-bibtex-copy-formatted-citation (entry)
@@ -486,17 +486,17 @@ this function to use it."
   (interactive)
   (ivy-read
    "action: "
-   (loop for i from 0
-	 for (_ func s) in
-	 org-ref-ivy-cite-actions
-	 collect (cons (format "%2s. %s" i s) func))
+   (cl-loop for i from 0
+	    for (_ func s) in
+	    org-ref-ivy-cite-actions
+	    collect (cons (format "%2s. %s" i s) func))
    :action (lambda (f)
 	     (let* ((key (car (org-ref-get-bibtex-key-and-file)))
 		    (entry (cdr (elt (orhc-bibtex-candidates)
 				     (-elem-index
 				      key
-				      (loop for entry in (orhc-bibtex-candidates)
-					    collect (cdr (assoc "=key=" entry ))))))))
+				      (cl-loop for entry in (orhc-bibtex-candidates)
+					       collect (cdr (assoc "=key=" entry ))))))))
 	       (funcall f entry)))))
 
 

--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -31,7 +31,7 @@
 (require 'f)
 (require 'pdf-tools)
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (declare-function org-ref-bibtex-key-from-doi "org-ref-bibtex.el")
 

--- a/org-ref-reftex.el
+++ b/org-ref-reftex.el
@@ -146,7 +146,7 @@ arg (ALTERNATIVE-CITE) to get a menu of citation types."
     (error "Org-ref-bib-bibliography-notes is not set to anything"))
 
   (org-open-link-from-string
-   (format "[[#%s]]" (first (reftex-citation t))))
+   (format "[[#%s]]" (car (reftex-citation t))))
   (funcall org-ref-open-notes-function))
 
 (defalias 'ornr 'org-ref-open-notes-from-reftex)

--- a/org-ref-url-utils.el
+++ b/org-ref-url-utils.el
@@ -46,7 +46,7 @@
 (require 'doi-utils)
 (require 'f)
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defgroup org-ref-url nil
   "Customization group for org-ref-url-utils"

--- a/test/org-ert.el
+++ b/test/org-ert.el
@@ -25,7 +25,7 @@
 (defun org-babel-goto-nth-test-block (n)
   "Move point to the Nth test block."
   (goto-char (point-min))
-  (loop for i from 1 to n do (org-goto-next-test-block))
+  (cl-loop for i from 1 to n do (org-goto-next-test-block))
   (recenter-top-bottom 1))
 
 


### PR DESCRIPTION
This removes `org-ref`'s reliance on the cl.el package, obsoleted since Emacs 24.3. 