### PR TITLE
Ensure that org-ref-find-bibliography returns a simple string

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -1874,7 +1874,7 @@ set in `org-ref-default-bibliography'"
                 ;; I added the + here to avoid matching +bibliography: keywords.
                 "\\(?:^[\[]\\{2\\}\\)?\\(bibliography\\|addbibresource\\):\\([^\]\|\n]+\\)"
                 nil t)
-          (dolist (bibfile (org-ref-split-and-strip-string (match-string 2)))
+          (dolist (bibfile (org-ref-split-and-strip-string (match-string-no-properties 2)))
 	    (let ((bibf (org-ref-find-bibfile bibfile)))
 	      (when bibf
 		(push bibf org-ref-bibliography-files)))))


### PR DESCRIPTION
Recent changes elsewhere meant that sometimes a string-with-properties
was being returned, which couldn't then be handed on to functions
expecting a string.