### PR TITLE
Capitalize booktitle field

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -489,66 +489,71 @@ title-case by org-ref-title-case."
 
 ;;;###autoload
 (defun org-ref-title-case (&optional key start end)
-  "Convert a bibtex entry title to title-case if the entry type
-is a member of the list org-ref-title-case-types. The arguments
-KEY, START and END are optional, and are only there so you can
-use this function with `bibtex-map-entries' to change all the
-title entries in articles and books."
+  "Convert a bibtex entry title and booktitle to title-case.
+Convert only if the entry type is a member of the list
+`org-ref-title-case-types'. The arguments KEY, START and END are
+optional, and are only there so you can use this function with
+`bibtex-map-entries' to change all the title entries in articles and
+books."
   (interactive)
-  (bibtex-beginning-of-entry)
+  (dolist (field '("title" "booktitle"))
+    (save-restriction
+      (bibtex-narrow-to-entry)
+      (bibtex-beginning-of-entry)
+      ;; Skip if field is not found in entry
+      (when (bibtex-search-forward-field field)
+	(let* ((title (bibtex-autokey-get-field field))
+	       (words (split-string title))
+	       (start 0))
+	  (when
+	      (member (downcase
+		       (cdr (assoc "=type=" (bibtex-parse-entry))))
+		      org-ref-title-case-types)
+	    (setq words (mapcar
+			 (lambda (word)
+			   (cond
+			    ;; words containing more than one . are probably
+			    ;; abbreviations. We do not change those.
+			    ((with-temp-buffer
+			       (insert word)
+			       (goto-char (point-min))
+			       (> (count-matches "\\.") 1))
+			     word)
+			    ;; match words containing {} or \ which are probably
+			    ;; LaTeX or protected words, ignore
+			    ((string-match "\\$\\|{\\|}\\|(\\|)\\|\\\\" word)
+			     word)
+			    ;; these words should not be capitalized, unless they
+			    ;; are the first word
+			    ((-contains? org-ref-lower-case-words
+					 (s-downcase word))
+			     (s-downcase word))
+			    ;; Words that are quoted
+			    ((s-starts-with? "\"" word)
+			     (concat "\"" (s-capitalize (substring word 1))))
+			    (t
+			     (s-capitalize word))))
+			 words))
 
-  (let* ((title (bibtex-autokey-get-field "title"))
-         (words (split-string title))
-         (start 0))
-    (when
-        (member (downcase
-		 (cdr (assoc "=type=" (bibtex-parse-entry))))
-		org-ref-title-case-types)
-      (setq words (mapcar
-                   (lambda (word)
-		     (cond
-		      ;; words containing more than one . are probably
-		      ;; abbreviations. We do not change those.
-		      ((with-temp-buffer
-			 (insert word)
-			 (goto-char (point-min))
-			 (> (count-matches "\\.") 1))
-		       word)
-		      ;; match words containing {} or \ which are probably
-		      ;; LaTeX or protected words, ignore
-		      ((string-match "\\$\\|{\\|}\\|(\\|)\\|\\\\" word)
-		       word)
-		      ;; these words should not be capitalized, unless they
-		      ;; are the first word
-		      ((-contains? org-ref-lower-case-words
-				   (s-downcase word))
-		       (s-downcase word))
-		      ;; Words that are quoted
-		      ((s-starts-with? "\"" word)
-		       (concat "\"" (s-capitalize (substring word 1))))
-		      (t
-		       (s-capitalize word))))
-                   words))
+	    ;; Check if first word should be capitalized
+	    (when (-contains? org-ref-lower-case-words (car words))
+	      (setf (car words) (s-capitalize (car words))))
 
-      ;; Check if first word should be capitalized
-      (when (-contains? org-ref-lower-case-words (car words))
-        (setf (car words) (s-capitalize (car words))))
+	    (setq title (mapconcat 'identity words " "))
 
-      (setq title (mapconcat 'identity words " "))
+	    ;; Capitalize letters after a dash
+	    (while
+		(string-match "[a-zA-Z]-\\([a-z]\\)" title start)
+	      (let ((char (substring title (match-beginning 1) (match-end 1))))
+		(setf (substring title (match-beginning 1) (match-end 1))
+		      (format "%s" (upcase char)))
+		(setq start (match-end 1))))
 
-      ;; Capitalize letters after a dash
-      (while
-          (string-match "[a-zA-Z]-\\([a-z]\\)" title start)
-        (let ((char (substring title (match-beginning 1) (match-end 1))))
-          (setf (substring title (match-beginning 1) (match-end 1))
-                (format "%s" (upcase char)))
-          (setq start (match-end 1))))
-
-      ;; this is defined in doi-utils
-      (bibtex-set-field
-       "title"
-       title)
-      (bibtex-fill-entry))))
+	    ;; this is defined in doi-utils
+	    (bibtex-set-field
+	     field
+	     title)
+	    (bibtex-fill-entry)))))))
 
 ;;;###autoload
 (defun org-ref-title-case-article (&optional key start end)


### PR DESCRIPTION
I basically wrapped the code with a `dolist` macro and replaced "title" with field so that booktitle field is also capitalized.
```
(dolist (field '("title" "booktitle"))	; <= added booktitle
  (save-restriction
    (bibtex-narrow-to-entry)
    (bibtex-beginning-of-entry)
    (when (bibtex-search-forward-field field) ; <= move forward only if field exists
      ;; code... <= replaced "title" with field
      )))
```