### PR TITLE
widen before getting label context

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -3203,7 +3203,8 @@ move to the beginning of the previous cite link after this one."
 ;;** context around org-ref links
 (defun org-ref-get-label-context (label)
   "Return a string of context around a LABEL."
-  (save-excursion
+  (save-excursion(save-restriction
+    (widen)
     (catch 'result
       (goto-char (point-min))
       (when (re-search-forward
@@ -3287,7 +3288,7 @@ move to the beginning of the previous cite link after this one."
 	(throw 'result (match-string 0)))
 
 
-      (throw 'result "!!! NO CONTEXT FOUND !!!"))))
+      (throw 'result "!!! NO CONTEXT FOUND !!!")))))
 
 
 ;;;###autoload


### PR DESCRIPTION
When I'm narrowing to a subtree and wants to add a ref link, the contexts of the labels are not displayed.
Instead there is just 
`| !!! NO CONTEXT FOUND !!!|`

This PR fixes this by widen it before getting the label context