### PR TITLE
Better PDF infrastructure

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -767,17 +767,15 @@ name '[bibtexkey].pdf'. If the file does not exist, rename it to
   (interactive "P")
   (save-excursion
     (bibtex-beginning-of-entry)
-    (let* ((file (read-file-name "Select file associated with entry: "))
-	   (bibtex-expand-strings t)
-           (entry (bibtex-parse-entry t))
+    (let* ((bibtex-expand-strings t)
+	       (entry (bibtex-parse-entry t))
            (key (reftex-get-bib-field "=key=" entry))
-           (pdf (concat org-ref-pdf-directory (concat key ".pdf")))
-	   (file-move-func (org-ref-bibtex-get-file-move-func prefix)))
+           (pdf (expand-file-name (concat key ".pdf") org-ref-pdf-directory))
+           (file-move-func (org-ref-bibtex-get-file-move-func prefix)))
       (if (file-exists-p pdf)
-	  (message (format "A file named %s already exists" pdf))
-	(progn
-	  (funcall file-move-func file pdf)
-	  (message (format "Created file %s" pdf)))))))
+	      (message "A file named %s already exists" pdf)
+	    (funcall file-move-func (read-file-name (format "Select file associated with entry %s: " key)) pdf)
+	    (message "Created file %s" pdf)))))
 
 
 ;;* Hydra menus

--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -777,6 +777,23 @@ name '[bibtexkey].pdf'. If the file does not exist, rename it to
 	    (funcall file-move-func (read-file-name (format "Select file associated with entry %s: " key)) pdf)
 	    (message "Created file %s" pdf)))))
 
+;;;###autoload
+(defun org-ref-bibtex-assoc-all (&optional prefix)
+  "Associate PDFs with all the entries that don't already have one.
+If you don't want to associate a specific entry with any PDF, you
+may quit with \\[keyboard-quit] and it will continue to the next
+one.
+See `org-ref-bibtex-assoc-pdf-with-entry' for more information
+about associating with PDFs."
+  (interactive "P")
+  (save-excursion
+    (goto-char (point-min))
+    (bibtex-map-entries (lambda (key begin end)
+                          (let ((inhibit-quit t))
+                            (cl-letf (((symbol-function 'message) (lambda (&rest _))))
+                              (with-local-quit (org-ref-bibtex-assoc-pdf-with-entry prefix))
+                              (setq quit-flag nil)))))))
+
 
 ;;* Hydra menus
 ;;** Hydra menu for bibtex entries


### PR DESCRIPTION
This pull request tries to make things more intuitive and keep the PDFs more in sync with the references file. 

There is a new command, `org-ref-bibtex-assoc-all`, which associates PDFs with all the entries that don't already have one.