### PR TITLE
Reference org-ref-help command

### DIFF
--- a/README.org
+++ b/README.org
@@ -140,7 +140,7 @@ Note many of these have been renamed with an org-ref prefix.
 
 * Manual
 
-For more information, see the [[https://github.com/jkitchin/org-ref/blob/master/org-ref.org][org-ref manual]].
+For more information, see the [[https://github.com/jkitchin/org-ref/blob/master/org-ref.org][org-ref manual]], or preferably use ~M-x org-ref-help~ in emacs.
 
 * Errors and issues
 


### PR DESCRIPTION
This is the prefered way to view the manual: https://github.com/jkitchin/org-ref/issues/464

I was very confused by reading the manual on github, and didn't understand how bibliography links / bibliographystyle links worked. These links are broken in the github version of the manual as referenced in the above issue.

I think we should mention that there's a built in version of the manual in emacs which doesn't have this issue!

Thanks!