### PR TITLE
Respect `org-ref-notes-function` when opening notes in ivy.

### DIFF
--- a/org-ref-ivy-cite.el
+++ b/org-ref-ivy-cite.el
@@ -113,10 +113,8 @@ ENTRY is selected from `orhc-bibtex-candidates'."
   "Open the notes associated with ENTRY.
 ENTRY is selected from `orhc-bibtex-candidates'."
   (with-ivy-window
-    (find-file (expand-file-name
-		(format "%s.org"
-			(cdr (assoc "=key=" entry)))
-		org-ref-notes-directory))))
+    (org-ref-open-notes-at-point
+     (cdr (assoc "=key=" entry)))))
 
 
 (defun or-ivy-bibtex-open-entry (entry)


### PR DESCRIPTION
Currently it always opens individual notes for each entry. Redirect it
to `org-ref-open-notes-at-point` with entry key so that it uses
user-defined `org-ref-notes-function`.