### PR TITLE
use nil key in org-ref-formatted-citation-formats

### DIFF
--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -1278,11 +1278,11 @@ of format strings used."
 	   (format-string)
 	   (ref))
       (if (null entry)
-	  "!!! No entry found !!!"
-	(setq format-string (or (cdr (assoc (downcase (bibtex-completion-get-value "=type=" entry)) formats))
-				"${author}, /${title}/ (${year})."))
-	(setq ref (s-format format-string 'bibtex-completion-apa-get-value entry))
-	(replace-regexp-in-string "\\([.?!]\\)\\." "\\1" ref)))))
+          "!!! No entry found !!!"
+        (setq format-string (cdr (or (assoc (downcase (bibtex-completion-get-value "=type=" entry)) formats)
+                                     (assoc nil formats))))
+        (setq ref (s-format format-string 'bibtex-completion-apa-get-value entry))
+        (replace-regexp-in-string "\\([.?!]\\)\\." "\\1" ref)))))
 
 
 (defun org-ref-format-entry (key)


### PR DESCRIPTION
The function `org-ref-format-bibtex-entry` currently uses the hard-coded fallback format string, but the fallback string is already defined within `org-ref-formatted-citation-formats` under the nil key.