### PR TITLE
Do not save point and buffer when jumping to notes headings

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2449,14 +2449,13 @@ long file with headlines for each entry."
         (car results))
        (bibfile
         (cdr results)))
-    (save-excursion
-      (with-temp-buffer
-        (insert-file-contents bibfile)
-        (bibtex-set-dialect
-         (parsebib-find-bibtex-dialect)
-         t)
-        (bibtex-search-entry key)
-        (org-ref-open-bibtex-notes)))))
+    (with-temp-buffer
+      (insert-file-contents bibfile)
+      (bibtex-set-dialect
+       (parsebib-find-bibtex-dialect)
+       t)
+      (bibtex-search-entry key)
+      (org-ref-open-bibtex-notes))))
 
 (defun org-ref-notes-function-many-files (thekey)
   "Function to open note belonging to THEKEY.


### PR DESCRIPTION
Error description: If notes.org is already opened, `org-ref-notes-function-one-file` will fail to jump to correct heading. 

Cause analysis: `save-excursion` resets the point. 

Fix: This commit removes `save-excursion` so that he can jump to correct heading even when the notes.org is already opened. 