### PR TITLE
doi-utils bibtex entry formatting improvements

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -821,8 +821,9 @@ MATCHING-TYPES."
                              (let ((field-expr
                                     (assoc field doi-utils-json-metadata-extract)))
                                (if field-expr
-                                   ;; need to convert to string first
-                                   `(,(car field-expr) (format "%s" ,(cadr field-expr)))
+                                   ;; Convert non-nil values to string
+                                   `(,(car field-expr) (if ,(cadr field-expr)
+                                                           (format "%s" ,(cadr field-expr))))
                                  (error "Unknown bibtex field type %s" field))))
                            fields)
                (concat

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -775,10 +775,10 @@ checked."
       (year       (elt (elt (plist-get (plist-get results :issued) :date-parts) 0) 0))
       ;; Some dates don't have a month in them.
       (month      (let ((date (elt
-			       (plist-get (plist-get results :issued) :date-parts) 0)))
-		    (if (>= (length date) 2)
-			(elt date 1)
-		      "-")))
+                               (plist-get (plist-get results :issued) :date-parts) 0)))
+                    (if (>= (length date) 2)
+                        (elt date 1)
+                      nil)))
       (pages      (or (plist-get results :page)
 		      (plist-get results :article-number)))
       (doi        (plist-get results :DOI))

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -765,7 +765,7 @@ checked."
       (author     (mapconcat (lambda (x) (concat (plist-get x :given) " " (plist-get x :family)))
                              (plist-get results :author) " and "))
       (title      (plist-get results :title))
-      (subtitle   (plist-get results :subtitle))
+      (subtitle   (mapconcat 'identity (plist-get results :subtitle) " "))
       (journal    (plist-get results :container-title))
       (series     (plist-get results :container-title))
       (publisher  (plist-get results :publisher))

--- a/doi-utils.el
+++ b/doi-utils.el
@@ -839,16 +839,16 @@ MATCHING-TYPES."
          doi-utils-bibtex-type-generators))
 
 (doi-utils-def-bibtex-type article ("journal-article" "article-journal")
-                           author title journal year volume number pages doi url)
+                           author title subtitle journal year volume number pages doi url)
 
 (doi-utils-def-bibtex-type inproceedings ("proceedings-article" "paper-conference")
-                           author title booktitle year month pages doi url)
+                           author title subtitle booktitle year month pages doi url)
 
 (doi-utils-def-bibtex-type book ("book")
-                           author title series publisher year pages doi url)
+                           author title subtitle series publisher year pages doi url)
 
 (doi-utils-def-bibtex-type inbook ("chapter" "book-chapter" "reference-entry")
-                           author title booktitle series publisher year pages doi url)
+                           author title subtitle booktitle series publisher year pages doi url)
 
 
 


### PR DESCRIPTION
This PR makes a few minor changes to the way bibtex entries are formatted in `doi-utils.el` to get cleaner results when the DOI entry is missing some fields (see before/after below). Also, it adds `subtitle` to the list of fields which are included in the entry by default.

Missing DOI entries are handeled by
 1) Ensuring that looking up the value for a missing field always reutrns nil
 2) Preventing a nil value from being turned into the string "nil"
 3) Relying on `org-ref-clean-bibtex-entry' to remove the resulting empty fields int he entry.

Before

```
@inproceedings{kaynak13_shift,
  author =	 {Cansu Kaynak and Boris Grot and Babak Falsafi},
  title =	 {SHIFT},
  booktitle =	 {Proceedings of the 46th Annual IEEE/ACM
                  International Symposium on Microarchitecture -
                  MICRO-46},
  year =	 2013,
  pages =	 {nil},
  doi =		 {10.1145/2540708.2540732},
  url =		 {https://doi.org/10.1145/2540708.2540732},
  DATE_ADDED =	 {Tue May 21 14:06:46 2019},
  month =	 {-},
}
```
After:
```
@inproceedings{kaynak13_shift,
  author =	 {Cansu Kaynak and Boris Grot and Babak Falsafi},
  title =	 {SHIFT},
  booktitle =	 {Proceedings of the 46th Annual IEEE/ACM
                  International Symposium on Microarchitecture -
                  MICRO-46},
  year =	 2013,
  doi =		 {10.1145/2540708.2540732},
  url =		 {https://doi.org/10.1145/2540708.2540732},
  DATE_ADDED =	 {Tue May 21 14:09:57 2019},
  subtitle =	 {shared history instruction fetch for lean-core
                  server processors},
}
```

