### PR TITLE
Fix minor regex mistakes

### DIFF
--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -218,7 +218,7 @@ key."
                        (match-end bibtex-key-in-head)))
             ;; remove potentially troublesome characters from key
             ;; as it will be used as  a filename
-            (setq key (replace-regexp-in-string   "\"\\|\\*\\|/\\|:\\|<\\|>\\|\\?\\|\\\\\\||\\|\\+\\|,\\|\\.\\|;\\|=\\|\\[\\|]\\|:\\|!\\|@"
+            (setq key (replace-regexp-in-string   "\"\\|\\*\\|/\\|:\\|<\\|>\\|\\?\\|\\\\\\||\\|\\+\\|,\\|\\.\\|;\\|=\\|\\[\\|]\\|!\\|@"
                                                   "" key))
             ;; check if the key is in the buffer
             (when (save-excursion

--- a/org-ref-bibtex.el
+++ b/org-ref-bibtex.el
@@ -1102,7 +1102,7 @@ easier to search specifically for them."
   (let ((s (replace-regexp-in-string
 	    "^{\\|}$" ""
 	    (replace-regexp-in-string
-	     "[\n\\|\t\\|\s]+" " "
+	     "[\n\t\s]+" " "
 	     (or (cdr (assoc field entry))
 		 (and (string= field "author")
 		      (cdr (assoc "editor" entry)))

--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -717,21 +717,21 @@ If so return the position for `goto-char'."
 (defvar org-ref-cite-re
   (concat "\\(" (mapconcat
                  (lambda (x)
-		   (replace-regexp-in-string "\*" "\\\\*" x))
+		   (replace-regexp-in-string "\\*" "\\\\*" x))
                  org-ref-cite-types "\\|") "\\):"
-                 "\\([a-zA-Z0-9-_:\\./]+,?\\)+")
+                 "\\([a-zA-Z0-9_:\\./-]+,?\\)+")
   "Regexp for cite links.
 Group 1 contains the cite type.
 Group 2 contains the keys.")
 
 
 (defvar org-ref-label-re
-  "label:\\([a-zA-Z0-9-_:]+,?\\)+"
+  "label:\\([a-zA-Z0-9_:-]+,?\\)+"
   "Regexp for label links.")
 
 
 (defvar org-ref-ref-re
-  "\\(eq\\)?ref:\\([a-zA-Z0-9-_:]+,?\\)+"
+  "\\(eq\\)?ref:\\([a-zA-Z0-9_:-]+,?\\)+"
   "Regexp for ref links.")
 
 
@@ -1735,7 +1735,7 @@ Stores a list of strings.")
     ;; label links
     "label:\\(?1:[+a-zA-Z0-9:\\._-]*\\)"
     ;; labels in latex
-    "\\label{\\(?1:[+a-zA-Z0-9:\\._-]*\\)}")
+    "\\\\label{\\(?1:[+a-zA-Z0-9:\\._-]*\\)}")
   "List of regexps that are labels in org-ref.")
 
 
@@ -2138,7 +2138,7 @@ properties."
 		    bibtex-key)))
 	    ;; point is on the link description, assume we want the
 	    ;; last key
-	    (let ((last-key (replace-regexp-in-string "[a-zA-Z0-9-_]*," "" link-string)))
+	    (let ((last-key (replace-regexp-in-string "[a-zA-Z0-9_-]*," "" link-string)))
 	      last-key))
 	;; link with description. assume only one key
 	link-string))))
@@ -2190,7 +2190,7 @@ set in `org-ref-default-bibliography'"
         ;; many.
         (goto-char (point-min))
         (while (re-search-forward
-                "\\\\addbibresource{\\(.*\\)?}"
+                "\\\\addbibresource{\\(.*\\)}"
                 nil t)
           (push (match-string 1) org-ref-bibliography-files))
 
@@ -3103,7 +3103,7 @@ file.  Makes a new buffer with clickable links."
     ;; Let us also check \attachfile{fname}
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "\\attachfile{\\([^}]*\\)}" nil t)
+      (while (re-search-forward "\\\\attachfile{\\([^}]*\\)}" nil t)
         (unless (file-exists-p (match-string 1))
           (add-to-list 'bad-files (cons (match-string 1) (point-marker))))))
     bad-files))

--- a/org-ref-helm.el
+++ b/org-ref-helm.el
@@ -300,7 +300,7 @@ at the end of you file.
 	(let ((matches '()))
 	  ;; these are the org-ref label:stuff  kinds
 	  (while (re-search-forward
-		  "[^#+]label:\\([a-zA-z0-9:-]*\\)" nil t)
+		  "[^#+]label:\\([a-zA-Z0-9:-]*\\)" nil t)
 	    (cl-pushnew (cons
 			 (match-string-no-properties 1)
 			 (point))
@@ -319,7 +319,7 @@ at the end of you file.
 	  ;; \label{}
 	  (save-excursion
 	    (goto-char (point-min))
-	    (while (re-search-forward "\\\\label{\\([a-zA-z0-9:-]*\\)}"
+	    (while (re-search-forward "\\\\label{\\([a-zA-Z0-9:-]*\\)}"
 				      nil t)
 	      (cl-pushnew (cons (match-string-no-properties 1) (point)) matches)))
 

--- a/org-ref-isbn.el
+++ b/org-ref-isbn.el
@@ -171,7 +171,7 @@ in the file. Data comes from worldcat."
 	 (entry))
     (with-current-buffer (url-retrieve-synchronously url t t)
       (goto-char (point-min))
-      (when (re-search-forward "@[a-zA-Z]+{.+\\(\n\s+[a-z\s={\.,?:;'0-9-\n}]+\\)+}$" nil t)
+      (when (re-search-forward "@[a-zA-Z]+{.+\\(\n\s+[a-z\s={\.,?:;'0-9\n}-]+\\)+}$" nil t)
 	(setq entry (match-string 0))))
 
     (if (not entry)

--- a/org-ref-latex.el
+++ b/org-ref-latex.el
@@ -33,7 +33,7 @@
 (defvar org-ref-latex-cite-re
   (concat "\\\\\\(" (mapconcat
 		     (lambda (x)
-		       (replace-regexp-in-string "\*" "\\\\*" x))
+		       (replace-regexp-in-string "\\*" "\\\\*" x))
 		     org-ref-cite-types
 		     "\\|")
 	  "\\)"


### PR DESCRIPTION
Some of these are mistakes (e.g. "\\label" instead of "\\\\label") and others are fine but typically viewed as bad style (e.g. "*" instead of "\\*").

The commit message has some more info on exactly how these were found and what the fixes are.