### PR TITLE
Fix doi-utils-add-bibtex-entry-from-doi when no trailing newline

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -981,9 +981,6 @@ Argument BIBFILE the bibliography to use."
       (if (word-search-forward (concat doi) nil t)
           (message "%s is already in this file" doi)
         (goto-char (point-max))
-	;; make sure we are at the beginning of a line
-	(when (not (= (point) (line-beginning-position)))
-	  (forward-char 1))
 
 	(when (not (looking-back "\n\n" (min 3 (point))))
 	  (insert "\n\n"))


### PR DESCRIPTION
`doi-utils-add-bibtex-entry-from-doi` will fail to add an bibtex entry if the bib
file does not have ending newline, and report end of buffer. There is no point
in running `(forward-char 1)` after `(goto-char (point-max))`, since you are already
at the end of the document. The bug was introduced in commit b12b8f05.