### PR TITLE
Allow duplicate keys in orcb-key

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -3307,8 +3307,10 @@ If optional NEW-YEAR set it to that, otherwise prompt for it."
     (insert ",")))
 
 
-(defun orcb-key ()
-  "Replace the key in the entry."
+(defun orcb-key (&optional allow-duplicate-keys)
+  "Replace the key in the entry.
+Prompts for replacement if the new key duplicates one already in
+the file, unless ALLOW-DUPLICATE-KEYS is non-nil."
   (let ((key (funcall org-ref-clean-bibtex-key-function
 		      (bibtex-generate-autokey))))
     ;; remove any \\ in the key
@@ -3320,8 +3322,9 @@ If optional NEW-YEAR set it to that, otherwise prompt for it."
 	(delete-region (match-beginning bibtex-key-in-head)
 		       (match-end bibtex-key-in-head)))
     ;; check if the key is in the buffer
-    (when (save-excursion
-	    (bibtex-search-entry key))
+    (when (and (not allow-duplicate-keys)
+               (save-excursion
+                 (bibtex-search-entry key)))
       (save-excursion
 	(bibtex-search-entry key)
 	(bibtex-copy-entry-as-kill)


### PR DESCRIPTION
I had occasion to deal with a big BibTeX file with possibly duplicate entries, and it would be much easier to work with the entries cleaned up with various org-ref functions. Some of the entries were either duplicates or resolved to the same cite-key. I tweaked `orcb-key`to take an optional argument `allow-duplicate-keys` that suppresses the check for duplicate keys in the rest of the file.

This might be useful in other situations. Since it's just a new optional argument, it shouldn't interfere with any existing uses. And it's fine if it doesn't seem appropriate for the main code.