### PR TITLE
Insert cite entry link to the end of the newly created note

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2702,6 +2702,7 @@ long file with headlines for each entry."
 	  (goto-char (point-max))
 	  (insert (org-ref-reftex-format-citation
 		   entry (concat "\n" org-ref-note-title-format)))
+    (insert (format "cite:%s\n" (org-entry-get (point) "Custom_ID")))
 	  (save-buffer))))))
 
 


### PR DESCRIPTION
Keep the original behavior of org-ref create new note, insert cite entry link at the end of the newly created note.