### PR TITLE
Fix dummy source in helm-tag-bibtex-entry

### DIFF
--- a/org-ref-helm.el
+++ b/org-ref-helm.el
@@ -464,10 +464,9 @@ Run this with the point in a bibtex entry."
                                         'identity
                                         (helm-marked-candidates)
                                         ", "))))))
-        (fallback-source `((name . "Add new keywords")
-                           (dummy)
-                           (action . (lambda (candidate)
-                                       (org-ref-set-bibtex-keywords helm-pattern))))))
+        (fallback-source (helm-build-dummy-source "Add new keywords"
+                           :action (lambda (candidate)
+                                     (org-ref-set-bibtex-keywords helm-pattern)))))
     (helm :sources `(,keyword-source ,fallback-source))))
 
 (provide 'org-ref-helm)


### PR DESCRIPTION
Recent helm versions have a different syntax for dummy sources so one cannot add new keywords as a fallback. This fixes it.