### PR TITLE
require 'cl-lib instead of 'cl

### DIFF
--- a/test/org-test-setup.el
+++ b/test/org-test-setup.el
@@ -59,7 +59,7 @@
 		       (cons
 			(expand-file-name "jump" org-test-dir)
 			load-path))))
-      (require 'cl)
+      (require 'cl-lib)
       (when (= emacs-major-version 22)
 	(defvar special-mode-map
 	  (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I'm the author of Org-roam, which supports Org-ref related functionality. I'm trying to pull down org-ref as a dependency in my CI, and it causes the CI to fail because of `cl` related warnings:

https://github.com/jethrokuan/org-roam/pull/562/checks?check_run_id=642493009#step:5:21

`org-ref` seems to be using `cl-lib` everywhere in the code, except for in the tests, where there is a single remaining `(require 'cl)`. Hopefully this small change makes all those warnings go away.

Ref: https://github.com/jethrokuan/org-roam/pull/562