### PR TITLE
Fix for finding bibliography files

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2205,13 +2205,13 @@ set in `org-ref-default-bibliography'"
   (-uniq
    (append
     ;; see if we should add it to a bib-file defined in the file
-    (org-ref-find-bibliography)
+    (list (org-ref-find-bibliography))
     ;; or any bib-files that exist in the current directory
     (f-entries "." (lambda (f)
 		     (and (not (string-match "#" f))
 			  (f-ext? f "bib"))))
     ;; and last in the default bibliography
-    org-ref-default-bibliography)))
+    (list org-ref-default-bibliography))))
 
 
 (defun org-ref-get-bibtex-key-and-file (&optional key)


### PR DESCRIPTION
`append` takes sequences, but `(org-ref-find-bibliograpyh)` and
`org-ref-default-bibliography` are strings. We need to listify them to
avoid adding a sequence of characters.