### PR TITLE
Fix error when bibtex dialect is not set

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2677,6 +2677,7 @@ long file with headlines for each entry."
   (let ((entry (with-temp-buffer
 		 (insert (org-ref-get-bibtex-entry key))
 		 (bibtex-mode)
+		 (bibtex-set-dialect nil t)
 		 (bibtex-beginning-of-entry)
 		 (bibtex-parse-entry)) ))
 


### PR DESCRIPTION
Inside the temp buffer, bibtex-parse-entry fails when bibtex-set-dialect has not been run yet. I think this is related to #746; it fixes the error for me.