### PR TITLE
org-ref-bibtex-files is expected to be a list.

### DIFF
--- a/org-ref-ivy-cite.el
+++ b/org-ref-ivy-cite.el
@@ -399,9 +399,9 @@ If candidate is already in, remove it."
 Uses `org-ref-find-bibliography' for bibtex sources, unless a
 prefix ARG is used, which uses `org-ref-default-bibliography'."
   (interactive "P")
-  (setq org-ref-bibtex-files (if arg
-				 org-ref-default-bibliography
-			       (org-ref-find-bibliography)))
+  (setq org-ref-bibtex-files (list (if arg
+                                       org-ref-default-bibliography
+                                     (org-ref-find-bibliography))))
   (setq org-ref-ivy-cite-marked-candidates '())
 
   (ivy-read "Open: " (orhc-bibtex-candidates)


### PR DESCRIPTION
I found after calling `org-ref-ivy-cite-completion` and then trying to insert a citation with `org-ref-insert-cite-link`, I wasn't getting any completions. I discovered that `org-ref-ivy-insert-cite-link` was setting `org-ref-bibtex-files` to be `org-ref-default-bibliography` (which works as just a string/file for helm-bibtex). Later, the following line is called in `orhc-bibtex-candidates`, indicating that `org-ref-bibtex-files` should be iterable (and not a string).
```emacs-lisp
(cl-loop for bibfile in org-ref-bibtex-files
		    collect (cdr (assoc bibfile candidates)))
```

My fix is really simple, but maybe I am just missing some intended behavior.