### PR TITLE
Update initial input for DOI and arxive IDs

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -919,59 +919,7 @@ Argument BIBFILE the bibliography to use."
    (list (read-string
           "DOI: "
           ;; now set initial input
-          (cond
-           ;; If region is active and it starts like a doi we want it.
-           ((and  (region-active-p)
-                  (s-match "^10" (buffer-substring
-                                  (region-beginning)
-                                  (region-end))))
-            (buffer-substring (region-beginning) (region-end)))
-	   ((and  (region-active-p)
-                  (s-match "^http://dx\\.doi\\.org/" (buffer-substring
-						      (region-beginning)
-						      (region-end))))
-            (replace-regexp-in-string "^http://dx\\.doi\\.org/" ""
-				      (buffer-substring (region-beginning) (region-end))))
-	   ((and  (region-active-p)
-		  (s-match "^https://dx\\.doi\\.org/" (buffer-substring
-						       (region-beginning)
-						       (region-end))))
-	    (replace-regexp-in-string "^https://dx\\.doi\\.org/" ""
-				      (buffer-substring (region-beginning) (region-end))))
-	   ((and  (region-active-p)
-                  (s-match (regexp-quote doi-utils-dx-doi-org-url) (buffer-substring
-								    (region-beginning)
-								    (region-end))))
-	    (replace-regexp-in-string  (regexp-quote doi-utils-dx-doi-org-url) ""
-				       (buffer-substring (region-beginning) (region-end)))
-            (buffer-substring (region-beginning) (region-end)))
-           ;; if the first entry in the kill-ring looks
-           ;; like a DOI, let's use it.
-           ((and
-             ;; make sure the kill-ring has something in it
-             (stringp (car kill-ring))
-             (s-match "^10" (car kill-ring)))
-            (car kill-ring))
-	   ;; maybe kill-ring matches http://dx.doi or somthing
-	   ((and
-             ;; make sure the kill-ring has something in it
-             (stringp (car kill-ring))
-             (s-match "^http://dx\\.doi\\.org/" (car kill-ring)))
-            (replace-regexp-in-string "^http://dx\\.doi\\.org/" "" (car kill-ring)))
-	   ((and
-             ;; make sure the kill-ring has something in it
-             (stringp (car kill-ring))
-             (s-match "^https://dx\\.doi\\.org/" (car kill-ring)))
-            (replace-regexp-in-string "^https://dx\\.doi\\.org/" "" (car kill-ring)))
-	   ((and
-             ;; make sure the kill-ring has something in it
-             (stringp (car kill-ring))
-             (s-match (regexp-quote doi-utils-dx-doi-org-url) (car kill-ring)))
-            (replace-regexp-in-string (regexp-quote doi-utils-dx-doi-org-url) "" (car kill-ring)))
-           ;; otherwise, we have no initial input. You
-           ;; will have to type it in.
-           (t
-            nil)))))
+          (doi-utils-maybe-doi-from-region-or-current-kill))))
 
   (unless bibfile
     (setq bibfile (completing-read "Bibfile: " (org-ref-possible-bibfiles))))
@@ -994,6 +942,53 @@ Argument BIBFILE the bibliography to use."
 
 (defalias 'doi-add-bibtex-entry 'doi-utils-add-bibtex-entry-from-doi
   "Alias function for convenience.")
+
+(defun doi-utils-maybe-doi-from-region-or-current-kill ()
+  "Try to get a DOI from the active region or current kill."
+  (let* ((the-active-region (if (region-active-p) ;; nil if no active region
+                                (buffer-substring (region-beginning) (region-end))
+                              nil))
+         (the-current-kill (ignore-errors (current-kill 0 t)))  ;; nil if empty kill ring
+         ;; DOI urls
+         ;; Ex: https://doi.org/10.1109/MALWARE.2014.6999410
+         ;; Ex: https://dx.doi.org/10.1007/978-3-319-60876-1_10
+         (doi-url-prefix-regexp "^https?://\\(dx\\.\\)?doi\\.org/")
+         ;; https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+         (doi-regexp "10\\.[0-9]\\{4,9\\}/[-._;()/:A-Z0-9]+$"))
+    (cond
+     ;; Check if a DOI can be found in the active region
+     ;; DOI raw
+     ;; Ex: 10.1109/MALWARE.2014.6999410
+     ((and (stringp the-active-region)
+           (s-match (concat "^" doi-regexp) the-active-region))
+      the-active-region)
+     ;; DOI url
+     ;; Ex: https://doi.org/10.1109/MALWARE.2014.6999410
+     ((and (stringp the-active-region)
+           (s-match (concat doi-url-prefix-regexp doi-regexp) the-active-region))
+      (replace-regexp-in-string doi-url-prefix-regexp "" the-active-region))
+     ;; DOI url as customized
+     ((and (stringp the-active-region)
+           (s-match (regexp-quote doi-utils-dx-doi-org-url) the-active-region))
+      (replace-regexp-in-string (regexp-quote doi-utils-dx-doi-org-url) "" the-active-region))
+     ;; Check if DOI can be found in the current kill
+     ;; DOI raw
+     ;; Ex: 10.1109/MALWARE.2014.6999410
+     ((and (stringp the-current-kill)
+           (s-match (concat "^" doi-regexp) the-current-kill))
+      the-current-kill)
+     ;; DOI url
+     ;; Ex: https://doi.org/10.1109/MALWARE.2014.6999410
+     ((and (stringp the-current-kill)
+           (s-match (concat doi-url-prefix-regexp doi-regexp) the-current-kill))
+      (replace-regexp-in-string doi-url-prefix-regexp "" the-current-kill))
+     ;; DOI url as customized
+     ((and (stringp the-current-kill)
+           (s-match (regexp-quote doi-utils-dx-doi-org-url) the-current-kill))
+      (replace-regexp-in-string (regexp-quote doi-utils-dx-doi-org-url) "" the-current-kill))
+     ;; otherwise, return nil
+     (t
+      nil))))
 
 ;;;###autoload
 (defun doi-utils-doi-to-org-bibtex (doi)

--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -150,12 +150,12 @@ Returns a formatted BibTeX entry."
 
 (defun arxiv-maybe-arxiv-id-from-current-kill ()
   "Try to get an arxiv ID from the current kill."
-  (let* ((the-current-kill (current-kill 0 t))
-        (arxiv-url-prefix-regexp "^https?://arxiv\\.org/\\(pdf\\|abs\\|format\\)/")
-        (arxiv-cite-prefix-regexp "^\\(arXiv\\|arxiv\\):")
-        (arxiv-id-old-regexp "[a-z-]+\\(\\.[A-Z]\\{2\\}\\)?/[0-9]\\{5,7\\}$") ; Ex: math.GT/0309136
-        (arxiv-id-new-regexp "[0-9]\\{4\\}[.][0-9]\\{4,5\\}\\(v[0-9]+\\)?$") ; Ex: 1304.4404v2
-        (arxiv-id-regexp (concat "\\(" arxiv-id-old-regexp "\\|" arxiv-id-new-regexp "\\)")))
+  (let* ((the-current-kill (ignore-errors (current-kill 0 t)))  ;; nil if empty kill ring
+         (arxiv-url-prefix-regexp "^https?://arxiv\\.org/\\(pdf\\|abs\\|format\\)/")
+         (arxiv-cite-prefix-regexp "^\\(arXiv\\|arxiv\\):")
+         (arxiv-id-old-regexp "[a-z-]+\\(\\.[A-Z]\\{2\\}\\)?/[0-9]\\{5,7\\}$") ; Ex: math.GT/0309136
+         (arxiv-id-new-regexp "[0-9]\\{4\\}[.][0-9]\\{4,5\\}\\(v[0-9]+\\)?$") ; Ex: 1304.4404v2
+         (arxiv-id-regexp (concat "\\(" arxiv-id-old-regexp "\\|" arxiv-id-new-regexp "\\)")))
   (cond
    (;; make sure current-kill has something in it
     ;; if current-kill is not a string, return nil


### PR DESCRIPTION
This pull request will update the initial input for DOI interactive function. Mainly it adds support for the system clipboard using `current-kill` instead of `kill-ring`. Regexes for url and DOI itself were merged/refined as well.

This also fixes a bug in a previous PR #771 for initial input for arxiv IDs where the function aborted in the case of an empty kill ring. (which is rather uncommon... but this should be taken into account) 