### PR TITLE
Fix for link type issue #774 

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2046,7 +2046,7 @@ and then backwards to get a comma, or the beginning of the link. that
 delimits the keyword we clicked on. We also strip the text
 properties."
   (let* ((object (org-element-context))
-	 (link-string (progn (org-in-regexp org-link-any-re)
+	 (link-string (progn (org-in-regexp org-link-types-re)
 			     (cadr (split-string
 				    (match-string-no-properties 0) ":")))))
     ;; you may click on the part before the citations. here we make


### PR DESCRIPTION
In current version of org (version 9.1.9) distributed with Emacs (version 26.3) there is no variable org-link-any-re which org-ref-core.el calls to identify links. Instead it seems the required information is now stored in org-link-types-re. This simple change fixes issue #774. 