### PR TITLE
Update ACM PDF url scheme

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -537,15 +537,11 @@ REDIRECT-URL is where the pdf url will be in."
               (match-string 1))))))))
 
 ;; ACM Digital Library
-;; http(s)://dl.acm.org/citation.cfm?doid=1368088.1368132
-;; <a name="FullTextPDF" title="FullText PDF" href="ft_gateway.cfm?id=1368132&ftid=518423&dwn=1&CFID=766519780&CFTOKEN=49739320" target="_blank">
+;; https://dl.acm.org/doi/10.1145/1368088.1368132
 (defun acm-pdf-url (*doi-utils-redirect*)
   "Get a url to the pdf from *DOI-UTILS-REDIRECT* for ACM urls."
   (when (string-match "^https?://dl.acm.org" *doi-utils-redirect*)
-    (with-current-buffer (url-retrieve-synchronously *doi-utils-redirect*)
-      (goto-char (point-min))
-      (when (re-search-forward "<a name=\"FullTextPDF\".*href=\"\\([[:ascii:]]*?\\)\"" nil t)
-	(concat "http://dl.acm.org/" (match-string 1))))))
+    (replace-regexp-in-string "doi" "doi/pdf" *doi-utils-redirect* )))
 
 ;;** Optical Society of America (OSA)
 (defun osa-pdf-url (*doi-utils-redirect*)


### PR DESCRIPTION
ACM Digital Library pages no longer link the PDF through a FullTextPDF tag. If
the user has access to the PDF, it is sufficient to modify the doi url.