### PR TITLE
Label type inference.

### DIFF
--- a/org-ref-helm.el
+++ b/org-ref-helm.el
@@ -117,7 +117,7 @@ Use a double \\[universal-argument] \\[universal-argument] to insert a
                                         ;; insert a new link
                                         (insert
                                          (concat
-                                          org-ref-default-ref-type ":" label))
+                                          (org-ref-infer-ref-type label) ":" label))
                                         )))
                                    ;; one prefix, alternate ref link
                                    ((equal helm-current-prefix-arg '(4))

--- a/org-ref-ivy-cite.el
+++ b/org-ref-ivy-cite.el
@@ -462,10 +462,9 @@ Use a prefix arg to select the ref type."
      (t
       (insert
        (or (when (looking-at "$") " ") "")
-       (concat org-ref-default-ref-type
+       (concat (org-ref-infer-ref-type label)
 	       ":"
 	       label))))))
-
 
 (require 'hydra)
 (setq hydra-is-helpful t)


### PR DESCRIPTION
Depending on the context in which a label is defined, the user may prefer different reference types. For example, it may be desired to have equations preferentially referenced using "eqref". This patch adds a variable `org-ref-ref-type-inference-alist' which contains pairs of predicates, which take the label text, and the desired label type if the predicate succeeds. When label completions are requested, instead of simply returning `org-ref-default-ref-type', the function `org-ref-infer-ref-type' is called with the label text. This function tries the predicates in `org-ref-ref-type-inference-alist' in order, and if one of them succeeds its label type is used. If none of the predicates match, `org-ref-default-ref-type' is used (maintaining backwards compatibility).