### PR TITLE
Use `reftex-parse-bibtex-entry` to parse bibtex entries for notes

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2687,10 +2687,11 @@ long file with headlines for each entry."
     (kill-ring-save (point-min) (point-max)))
   (let ((entry (with-temp-buffer
 		 (insert (org-ref-get-bibtex-entry key))
-		 (bibtex-mode)
-		 (bibtex-set-dialect nil t)
-		 (bibtex-beginning-of-entry)
-		 (bibtex-parse-entry)) ))
+                 (setq entry (reftex-parse-bibtex-entry nil (point-min) (point-max)))
+                 ;; add =key= and =type= for code which expects `bibtex-parse-entry` style
+                 (add-to-list 'entry
+                              (cons "=key=" (reftex-get-bib-field "&key" entry))
+                              (cons "=type=" (reftex-get-bib-field "&type" entry))))))
 
     (save-restriction
       (if  org-ref-bibliography-notes


### PR DESCRIPTION
I ran into some problems when creating notes for bibtex items with org-ref due to formatting especially when bibtex fields are multi-lined.
Entries parsed by `reftex-parse-bibtex-entry` are are better stripped
than those parsed by `bibtex-parse-entry`.

For code using entries parsed by `bibtex-parse-entry`, I added missing keys which do follow a different naming scheme.

I am open for discussing code and issue.