### PR TITLE
Add simple ads support in helm and doi menu

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -1205,6 +1205,15 @@ May be empty if none are found."
            "&svc_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Asch_svc&svc.related=yes")))
 
 
+;;* DOI functions for ADS
+
+;;;###autoload
+(defun doi-utils-ads (doi)
+  "Open ADS entry for DOI"
+  (interactive "sDOI: ")
+  (browse-url
+   (concat
+    "https://ui.adsabs.harvard.edu/abs/" "%22" doi "%22")))
 
 
 ;;* A new doi link for org-mode
@@ -1274,6 +1283,7 @@ must take one argument, the doi.")
         ("w" "os" doi-utils-wos)
         ("c" "iting articles" doi-utils-wos-citing)
         ("r" "elated articles" doi-utils-wos-related)
+        ("a" "ds" doi-utils-ads)
         ("s" "Google Scholar" doi-utils-google-scholar)
         ("f" "CrossRef" doi-utils-crossref)
         ("p" "ubmed" doi-utils-pubmed)

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -606,6 +606,8 @@ Checks for pdf and doi, and add appropriate functions."
             `(("WOS" . org-ref-wos-at-point)
               ("Related articles in WOS" . org-ref-wos-related-at-point)
               ("Citing articles in WOS" . org-ref-wos-citing-at-point)
+              ("ADS" . org-ref-ads-at-point)
+              ("Related articles in ADS" . org-ref-ads-related-at-point)
               ("Google Scholar" . org-ref-google-scholar-at-point)
               ("Pubmed" . org-ref-pubmed-at-point)
               ("Crossref" . org-ref-crossref-at-point))))

--- a/org-ref-helm-cite.el
+++ b/org-ref-helm-cite.el
@@ -607,7 +607,6 @@ Checks for pdf and doi, and add appropriate functions."
               ("Related articles in WOS" . org-ref-wos-related-at-point)
               ("Citing articles in WOS" . org-ref-wos-citing-at-point)
               ("ADS" . org-ref-ads-at-point)
-              ("Related articles in ADS" . org-ref-ads-related-at-point)
               ("Google Scholar" . org-ref-google-scholar-at-point)
               ("Pubmed" . org-ref-pubmed-at-point)
               ("Crossref" . org-ref-crossref-at-point))))

--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -568,6 +568,14 @@ directory.  You can also specify a new file."
 
 
 ;;**** functions that operate on key at point for click menu
+
+;;;###autoload
+(defun org-ref-ads-at-point ()
+  "Open the doi in ADS for bibtex key under point."
+  (interactive)
+  (doi-utils-ads (org-ref-get-doi-at-point)))
+
+
 ;;;###autoload
 (defun org-ref-wos-at-point ()
   "Open the doi in wos for bibtex key under point."


### PR DESCRIPTION
I think `org-ref` lacks ADS support,
since it can do many things that `WOS` can and can be used
without an academic account.

Sadly I don't know exactly how many menus `org-ref`
has, if someone hints me the way to go I can do it,
or maybe someone can also contribute to this PR.

Basically it works like this
given the doi

```
10.1016/0375-9601(74)90283-7
```

we can jump to ads by browsing

```
https://ui.adsabs.harvard.edu/abs/%22{doi}%22
```

ADS works with bibcodes (to my regret), and using the
bibcode one can go to 

- [ ] citing articles
  ```
  https://ui.adsabs.harvard.edu/abs/{bibcode}/citations
  ```
- [ ] References
  ```
  https://ui.adsabs.harvard.edu/abs/{bibcode}/references
  ```
- [ ] Similar
  ```
  https://ui.adsabs.harvard.edu/abs/{bibcode}/similar
  ```

However for some reason this does not work with the `{doi}`
because the first GET request to the previously defined ads
url basically redirects to the correspondent url with the bibcode,
i.e.

```
https://ui.adsabs.harvard.edu/abs/%22{doi}%22
```

redirects to

```
https://ui.adsabs.harvard.edu/abs/{bibcode}
```

and trying to do
```
https://ui.adsabs.harvard.edu/abs/%22{doi}%22/citations
```
is futile.

Therefore maybe we could write a function that
uses ADS to get the bibcode and use the bibcode
to do the get requests.


Therefore this pull request should strive to do the following:

- [ ] Write a doi to bibcode function.
- [ ] Add ads to all menus
- [ ] Create citations function and add it to menus
- [ ] Create references function and add it to menus
- [ ] Create similar function and add it to menus
