### PR TITLE
Don't overwrite user's customization to bibtex-completion-display-formats

### DIFF
--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -112,10 +112,18 @@ The cdr of the the cons cell is the function to use."
 
 
 ;;* Helm bibtex setup.
-(setq bibtex-completion-additional-search-fields '(keywords))
+(unless (or (member 'keywords bibtex-completion-additional-search-fields)
+            (member "keywords" bibtex-completion-additional-search-fields))
+  ;; Both symbol and string values are accepted, but b-c-a-s-f's
+  ;; Custom :type specifies string.
+  (push "keywords" bibtex-completion-additional-search-fields))
 
-(setq bibtex-completion-display-formats
-      '((t . "${author:36} ${title:*} ${year:4} ${=has-pdf=:1}${=has-note=:1} ${=type=:7} ${keywords:31}")))
+(let ((display-format
+       (alist-get t bibtex-completion-display-formats)))
+  (unless (string-match-p "{keywords:"
+                          display-format)
+    (setf (alist-get t bibtex-completion-display-formats)
+          (concat display-format " ${keywords:31}"))))
 
 (defun bibtex-completion-copy-candidate (_candidate)
   "Copy the selected bibtex entries to the clipboard.

--- a/org-ref-helm-bibtex.el
+++ b/org-ref-helm-bibtex.el
@@ -111,19 +111,25 @@ The cdr of the the cons cell is the function to use."
       org-ref-cite-onclick-function 'org-ref-cite-click-helm)
 
 
-;;* Helm bibtex setup.
-(unless (or (member 'keywords bibtex-completion-additional-search-fields)
-            (member "keywords" bibtex-completion-additional-search-fields))
-  ;; Both symbol and string values are accepted, but b-c-a-s-f's
-  ;; Custom :type specifies string.
-  (push "keywords" bibtex-completion-additional-search-fields))
+(defcustom org-ref-bibtex-completion-add-keywords-field t
+  "Whether to add the `keywords' field to bibtex-completion."
+  :group 'org-ref
+  :type 'boolean)
 
-(let ((display-format
-       (alist-get t bibtex-completion-display-formats)))
-  (unless (string-match-p "{keywords:"
-                          display-format)
-    (setf (alist-get t bibtex-completion-display-formats)
-          (concat display-format " ${keywords:31}"))))
+
+;;* Helm bibtex setup.
+(when org-ref-bibtex-completion-add-keywords-field
+  (unless (or (member 'keywords bibtex-completion-additional-search-fields)
+              (member "keywords" bibtex-completion-additional-search-fields))
+    ;; Both symbol and string values are accepted, but b-c-a-s-f's
+    ;; Custom :type specifies string.
+    (push "keywords" bibtex-completion-additional-search-fields))
+  (let ((display-format
+         (alist-get t bibtex-completion-display-formats)))
+    (unless (string-match-p "{keywords:"
+                            display-format)
+      (setf (alist-get t bibtex-completion-display-formats)
+            (concat display-format " ${keywords:31}")))))
 
 (defun bibtex-completion-copy-candidate (_candidate)
   "Copy the selected bibtex entries to the clipboard.

--- a/org-ref.org
+++ b/org-ref.org
@@ -267,9 +267,13 @@ This may be slow in large files, so you can turn it off by setting that variable
 :END:
 index:helm-bibtex
 
-org-ref adds a few new features to helm-bibtex. First, we add keywords as a searchable field. Second, org-ref modifies the helm-bibtex search buffer to include the keywords. Since keywords now can have a central role in searching, we add some functionality to add keywords from the helm-bibtex buffer as a new action.
+org-ref adds a few new features to helm-bibtex.
+
+First, we add =keywords= as a searchable field, and modify the helm-bibtex search buffer to include the keywords. Since keywords now can have a central role in searching, we add some functionality to add keywords from the helm-bibtex buffer as a new action.
 
 We change the order of the actions in helm-bibtex to suit our work flow, and add some new actions as well. We define a format function for org-mode that is compatible with the usage defined in section [[#citations]]. Finally, we add some new fallback options for additional scientific search engines.
+
+The =keywords= field is added onto the existing value, such that existing customization wouldn’t be lost; if you still prefer to add the field yourself, set ~org-ref-bibtex-completion-add-keywords-field~ to nil before loading org-ref.
 
 ** Some basic org-ref utilities
 [[index:bibtex!clean entry]]

--- a/org-ref.org
+++ b/org-ref.org
@@ -83,7 +83,7 @@ index:cite
 
 org-ref uses the [[bibliography link]] to determine which bibtex files to get citations from, and falls back to the bibtex files defined in the variable ~reftex-default-bibliography~ or ~org-ref-default-bibliography~ if no bibliography link is found. Note that you *must* include a [[bibliography link]] in your document if you are exporting your document to pdf; ~org-ref-default-bibliography~ is not used by the [[BibTeX users][LaTeX exporter]].
 
-For simple citation needs, org-ref is simple to use. At the point you want to insert a citation, you select the "Org -> org-ref -> Insert citation" menu (or use the key-binding ~C-c ]~ by default), select the reference(s) you want in the helm-bibtex buffer and press enter. The citation will be inserted automatically into your org-file. You "select" an entry by using the arrow keys (or ~C-n~ and ~C-p~) to move up and down to the entry you want. You can also narrow the selection by typing a pattern to match, e.g. author name, title words, year, BibTeX key and entry types. For any other field (e.g. keywords), you will need to add it to the variable ~bibtex-completion-additional-search-fields~. You can select multiple entries by pressing ~C-SPC~ to mark entries in the helm-bibtex buffer.
+For simple citation needs, org-ref is simple to use. At the point you want to insert a citation, you select the "Org -> org-ref -> Insert citation" menu (or use the key-binding ~C-c ]~ by default), select the reference(s) you want in the helm-bibtex buffer and press enter. The citation will be inserted automatically into your org-file. You "select" an entry by using the arrow keys (or ~C-n~ and ~C-p~) to move up and down to the entry you want. You can also narrow the selection by typing a pattern to match, e.g. author name, title words, year, BibTeX key and entry types. If you want to match any other field, you need to add it to the variable ~bibtex-completion-additional-search-fields~; org-ref [[id:5d7a19d3-0411-4964-9154-99af4f281015][does this automatically]] for the ~keywords~ field. You can select multiple entries by pressing ~C-SPC~ to mark entries in the helm-bibtex buffer.
 
 If the cursor is on a citation key, you should see a message in the minibuffer that summarizes which citation it refers to. If you click on a key, you should see a helm selection buffer with some actions to choose, including opening the bibtex entry, opening/getting a pdf for the entry, searching the entry in Web of Science, etc...
 
@@ -262,6 +262,9 @@ Org-ref can also be configured to show bad label,ref and cite links by setting t
 This may be slow in large files, so you can turn it off by setting that variable to nil.
 
 ** org-ref customization of helm-bibtex
+:PROPERTIES:
+:ID:       5d7a19d3-0411-4964-9154-99af4f281015
+:END:
 index:helm-bibtex
 
 org-ref adds a few new features to helm-bibtex. First, we add keywords as a searchable field. Second, org-ref modifies the helm-bibtex search buffer to include the keywords. Since keywords now can have a central role in searching, we add some functionality to add keywords from the helm-bibtex buffer as a new action.


### PR DESCRIPTION
Fixes #799.

- Instead of overwriting `bibtex-completion-display-formats` and `bibtex-completion-additional-search-fields`, append into them.
- Add a new user option, `org-ref-bibtex-completion-add-keywords-field`, that when set to nil disables the modification of these variables altogether.
- Adopt the documentation for these changes