### PR TITLE
Add documentation for ac, Ac, acp and Acp acronym links

### DIFF
--- a/org-ref.org
+++ b/org-ref.org
@@ -874,7 +874,11 @@ org-ref provides some support for glossary and acronym definitions.
 - glssymbol :: The symbol term
 - glsdesc :: The description of the term
 
-- acrshort :: Short version of the acroynm
+- ac :: a reference to an acronym
+- Ac :: capitalized reference to an acronym
+- acp :: a plural reference to an acronym
+- Acp :: capitalized plural reference to an acronym
+- acrshort :: Short version of the acronym
 - acrfull :: The full definition of the acronym
 - acrlong :: The full definition of the acronym with (abbrv).
 


### PR DESCRIPTION
This pull request adds documentation for the `ac`, `acp`, `Ac` and `Acp` acronym links which are already supported by org-ref.

I have even created [an issue](https://github.com/jkitchin/org-ref/issues/804) to create equivalent commands for the `gls*` commands for acronyms, but these are already supported by org-ref and only the documentation is missing.


