### PR TITLE
Fix org-ref-notes-function-many-files to find notes in a directory

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2906,9 +2906,10 @@ long file with headlines for each entry."
   "Function to open note belonging to THEKEY.
 Set `org-ref-notes-function' to this function if you use one file
 for each bib entry."
-  (let ((bibtex-completion-bibliography (org-ref-find-bibliography)))
-    (bibtex-completion-edit-notes
-     (list (car (org-ref-get-bibtex-key-and-file thekey))))))
+  (let* ((bibtex-completion-bibliography
+          (cdr (org-ref-get-bibtex-key-and-file thekey)))
+         (bibtex-completion-notes-path org-ref-notes-directory))
+    (bibtex-completion-edit-notes thekey)))
 
 ;;** Open notes from bibtex entry
 ;;;###autoload


### PR DESCRIPTION
Inside org-ref-notes-function-many-files:
1. Call bibtex-completion-edit-notes with the key, per the function
   signature.
2. Bind bibtex-completion-bibliography to the BibTeX file found to
   contain the key.
3. Bind bibtex-completion-notes-path to org-ref-notes-directory so the
   user doesn't have to set both paths.