### PR TITLE
Encode URL for Google Scholar queries

### DIFF
--- a/org-ref-url-utils.el
+++ b/org-ref-url-utils.el
@@ -192,14 +192,7 @@ no DOI is found, we create a misc entry, with a prompt for a key."
 	  action)
 	 ;; No DOIs found, add a misc entry.
 	 (t
-	  (goto-char (point-max))
-	  (insert (format "\n@misc{,
-    url = {%s},
-    note = {Last accessed %s}
-  }"
-			  url
-			  (current-time-string)))
-	  (bibtex-clean-entry)
+          (org-ref-url-html-to-bibtex (buffer-file-name) url)
 	  action)))
     ;; pass back to dnd. Copied from `org-download-dnd'. Apparently
     ;; returning nil does not do this.
@@ -300,15 +293,7 @@ not perfect, and some hits are not actually DOIs."
 	  (bibtex-beginning-of-entry)
 	  (delete-char -2))
       ;; no doi, add misc
-      (goto-char (point-max))
-	  (insert (format "\n@misc{,
-    url = {%s},
-    note = {Last accessed %s}
-  }"
-			  url
-			  (current-time-string)))
-	  (bibtex-clean-entry))))
-
+      (org-ref-url-html-to-bibtex (buffer-file-name) url))))
 
 ;;;###autoload
 (defun org-ref-url-dnd-first (event)
@@ -364,8 +349,10 @@ Fields include author, title, url, urldate, and year."
 
       ;; find author
       (goto-char (point-min))
-      (when (re-search-forward org-ref-url-author-re nil t)
-	(push (cons :author (match-string 1)) fields))
+      (let ((author (if (re-search-forward org-ref-url-author-re nil t)
+                        (match-string 1)
+                      "Unknown")))
+        (push (cons :author author) fields))
 
       ;; find title
       (goto-char (point-min))

--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -618,18 +618,19 @@ directory.  You can also specify a new file."
   "Search google scholar for bibtex key under point using the title."
   (interactive)
   (browse-url
-   (format
-    "http://scholar.google.com/scholar?q=%s"
-    (let* ((key-file (org-ref-get-bibtex-key-and-file))
-	   (key (car key-file))
-	   (file (cdr key-file))
-	   entry)
-      (with-temp-buffer
-	(insert-file-contents file)
-	(bibtex-set-dialect (parsebib-find-bibtex-dialect) t)
-	(bibtex-search-entry key nil 0)
-	(setq entry (bibtex-parse-entry))
-	(org-ref-reftex-get-bib-field "title" entry))))))
+   (url-encode-url
+    (format
+     "http://scholar.google.com/scholar?q=%s"
+     (let* ((key-file (org-ref-get-bibtex-key-and-file))
+            (key (car key-file))
+            (file (cdr key-file))
+            entry)
+       (with-temp-buffer
+         (insert-file-contents file)
+         (bibtex-set-dialect (parsebib-find-bibtex-dialect) t)
+         (bibtex-search-entry key nil 0)
+         (setq entry (bibtex-parse-entry))
+         (org-ref-reftex-get-bib-field "title" entry)))))))
 
 
 ;;;###autoload


### PR DESCRIPTION
`browse-url` doesn't handle URLs with spaces, so url-encode before calling it.