### PR TITLE
Fix OOB problem with org-ref-delete-labels

### DIFF
--- a/org-ref-core.el
+++ b/org-ref-core.el
@@ -2033,9 +2033,11 @@ missing."
   ;; not perfect, this can be nil for anonyomous derived backends.
   (when (and org-ref-labels
 	     (not org-export-current-backend))
-    (if (eq start end)
-	(org-ref-delete-labels-insertion start end)
-      (org-ref-delete-labels-deletion start end)))
+    (save-restriction
+      (widen)
+      (if (eq start end)
+	  (org-ref-delete-labels-insertion start end)
+        (org-ref-delete-labels-deletion start end))))
   (when org-ref-label-debug
     (message "end: %S" org-ref-labels)
     (message "ordl end-----------------------------------------------------------------")))


### PR DESCRIPTION
* org-ref-core.el (org-ref-delete-labels): Temporarily widen buffer before
grabbing text-properties

`get-text-property` is used at many points within modules of
`org-ref-delete-labels`, but it errors when trying to grab the properties
beyond the buffer’s restriction (i.e. narrowing).  This is particularly
problematic for a function that hooks onto `before-change-functions`.

Saving the restriction and widening the buffer during operation resolves the
issue, but considering the call-frequency of `before-change-functions`,
refactoring will have to be considered down the line.