### PR TITLE
treat `org-ref-pdf-directory` as list or string of directory

### DIFF
--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -393,16 +393,19 @@ This searches for the pattern KEY*.pdf. If one result is found it
 is returned, but if multiple results are found, e.g. there are
 related files to the KEY you are prompted for which one you want."
   (if org-ref-pdf-directory
-      (let ((pdfs (-flatten (--map (file-expand-wildcards
-				    (f-join it (format "%s*.pdf" key)))
-				   (-flatten (list org-ref-pdf-directory))))))
-	(cond
-	 ((= 0 (length pdfs))
-	  (expand-file-name (format "%s.pdf" key) org-ref-pdf-directory))
-	 ((= 1 (length pdfs))
-	  (car pdfs))
-	 ((> (length pdfs) 1)
-	  (completing-read "Choose: " pdfs))))
+      (let* ((pdf-dirs (if (listp org-ref-pdf-directory)
+                           org-ref-pdf-directory
+                         (list org-ref-pdf-directory)))
+             (pdfs (-flatten (--map (file-expand-wildcards
+                     (f-join it (format "%s*.pdf" key)))
+                    (-flatten pdf-dirs)))))
+	    (cond
+	     ((= 0 (length pdfs))
+	      (expand-file-name (format "%s.pdf" key) org-ref-pdf-directory))
+	     ((= 1 (length pdfs))
+	      (car pdfs))
+	     ((> (length pdfs) 1)
+	      (completing-read "Choose: " pdfs))))
     ;; No org-ref-pdf-directory defined so return just a file name.
     (format "%s.pdf" key)))
 

--- a/test/all-org-test.org
+++ b/test/all-org-test.org
@@ -595,6 +595,36 @@ label:one
 
 
 
+#+name: or-get-pdf-3
+#+BEGIN_SRC emacs-lisp :test
+(should
+ (string=
+  (expand-file-name
+   "tests/bibtex-pdfs/kitchin-2015.pdf"
+   (file-name-directory
+    (locate-library "org-ref")))
+  (org-test-with-temp-text
+      "cite:kitchin-2015"
+    (let ((org-ref-pdf-directory (list (expand-file-name
+				                        "tests/bibtex-pdfs/"
+				                        (file-name-directory
+				                         (locate-library "org-ref"))))))
+      (org-ref-get-pdf-filename (org-ref-get-bibtex-key-under-cursor))))))
+
+#+END_SRC
+
+#+RESULTS: or-get-pdf-3
+: t
+
+
+
+
+
+
+
+
+
+
 
 
 


### PR DESCRIPTION
`org-ref-pdf-directory` can be plain directory or a list of directories:

```emacs-lisp
(defcustom org-ref-pdf-directory
  nil
  "Directory where pdfs are stored by key.
Put a trailing / in the name."
  :type '(choice directory (repeat directory))
  :group 'org-ref)
```

This PR make it possible that both directory and list of directories is acceptable by `org-ref-get-pdf-filename`.