### PR TITLE
ascii export with better newline format

### DIFF
--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -837,9 +837,12 @@ if SORT is non-nil the bibliography is sorted alphabetically by key."
   (let ((keys (org-ref-get-bibtex-keys sort)))
     (when keys
       (concat
-       "\n\nBibliography\n=============\n\n"
-       (mapconcat (lambda (x) (org-ref-get-bibtex-entry-ascii x)) keys "\n")
-       "\n"))))
+       hard-newline hard-newline
+       "Bibliography" hard-newline
+       "=============" hard-newline hard-newline
+       (mapconcat (lambda (x) (org-ref-get-bibtex-entry-ascii x)) keys
+                  (concat hard-newline hard-newline))
+       hard-newline))))
 
 (defun org-ref-get-md-bibliography (&optional sort)
   "Create an md bibliography when there are keys.


### PR DESCRIPTION
when exporting to ascii, the bibliography items are not separated by newline:

```
  Bibliography ============= [kitchin-2015-examp] Kitchin, Examples of
  Effective Data Sharing in Scientific Publishing, <i>{ACS
  Catalysis}</i>, <b>5(6)</b>, 3894-3899 (2015). <a href="
  http://dx.doi.org/10.1021/acscatal.5b00538 ">link</a>. <a
  href="http://dx.doi.org/10.1021/acscatal.5b00538">doi</a>.
  [akhade-2012-effec] Akhade \& Kitchin, Effects of Strain, d-Band
  Filling, and Oxidation State on the Surface Electronic Structure and
  Reactivity of 3d Perovskite Surfaces, <i>{J. Chem. Phys.}</i>,
  <b>137()</b>, 084703 (2012). <a
  href="http://scitation.aip.org/content/aip/journal/jcp/137/8/10.1063/1.4746117">link</a>. <a
  href="http://dx.doi.org/10.1063/1.4746117">doi</a>.  [xu-2015-relat]
  Zhongnan Xu \& John Kitchin, Relationships Between the Surface
  Electronic and Chemical Properties of Doped 4d and 5d Late Transition
  Metal Dioxides, <i>{The Journal of Chemical Physics}</i>,
  <b>142(10)</b>, 104703 (2015). <a
  href="http://dx.doi.org/10.1063/1.4914093">link</a>. <a
  href="http://dx.doi.org/10.1063/1.4914093">doi</a>.
```

This PR replaces "\n" with `hard-newline`, it looks better:

```
  Bibliography
  =============

  [kitchin-2015-examp] Kitchin, Examples of Effective Data Sharing in
  Scientific Publishing, <i>{ACS Catalysis}</i>, <b>5(6)</b>, 3894-3899
  (2015). <a href=" http://dx.doi.org/10.1021/acscatal.5b00538
  ">link</a>. <a
  href="http://dx.doi.org/10.1021/acscatal.5b00538">doi</a>.

  [akhade-2012-effec] Akhade \& Kitchin, Effects of Strain, d-Band
  Filling, and Oxidation State on the Surface Electronic Structure and
  Reactivity of 3d Perovskite Surfaces, <i>{J. Chem. Phys.}</i>,
  <b>137()</b>, 084703 (2012). <a
  href="http://scitation.aip.org/content/aip/journal/jcp/137/8/10.1063/1.4746117">link</a>. <a
  href="http://dx.doi.org/10.1063/1.4746117">doi</a>.

  [xu-2015-relat] Zhongnan Xu \& John Kitchin, Relationships Between the
  Surface Electronic and Chemical Properties of Doped 4d and 5d Late
  Transition Metal Dioxides, <i>{The Journal of Chemical Physics}</i>,
  <b>142(10)</b>, 104703 (2015). <a
  href="http://dx.doi.org/10.1063/1.4914093">link</a>. <a
  href="http://dx.doi.org/10.1063/1.4914093">doi</a>.
```