### PR TITLE
Add file keyword when downloading pdf from Arxiv

### DIFF
--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -275,6 +275,9 @@ key."
               (setq key (bibtex-read-key "Duplicate Key found, edit: " key))))
         (setq key (bibtex-read-key "Key not found, insert: ")))
       (insert key)
+      (bibtex-end-of-entry)
+      (backward-char)
+      (insert (format "  file = {%s}\n  " (concat pdfdir key ".pdf")))
       (arxiv-get-pdf arxiv-number (concat pdfdir key ".pdf")))))
 
 (provide 'org-ref-arxiv)


### PR DESCRIPTION
When downloading the PDF while retrieving some entry, it might not hurt to include the file keyword.
Furthermore, adding this allows the file to be opened easily from [ebib](https://github.com/joostkremers/ebib).