### PR TITLE
Fix the value of 'org-ref-cite-types' variable

### DIFF
--- a/org-ref-citation-links.el
+++ b/org-ref-citation-links.el
@@ -209,7 +209,7 @@ This is mostly for multicites and natbib."
    org-ref-biblatex-types
    org-ref-biblatex-multitypes
    ;; for the bibentry package
-   '("bibentry" "Insert the bibtex entry"))
+   '(("bibentry" "Insert the bibtex entry")))
   "List of citation types known in `org-ref'."
   :type '(repeat :tag "List of citation types (type description)" (list string string))
   :group 'org-ref)


### PR DESCRIPTION
Hello, if you check the value of `org-ref-cite-types` variable, you get:

```
(("cite" "basic citation")
 ("nocite" "add key to bibliography, but do not cite it in the text")
 ...
 "bibentry"
 "Insert the bibtex entry")
```

I think it should be this instead, right?

```
(("cite" "basic citation")
 ("nocite" "add key to bibliography, but do not cite it in the text")
 ...
 ("bibentry" "Insert the bibtex entry"))
```

This bug was introduced by commit fcc728e1f82369284874c57f1625d7b0b827d7e9
