### PR TITLE
Set org-link description to citation's title

### DIFF
--- a/org-ref-citation-links.el
+++ b/org-ref-citation-links.el
@@ -1289,22 +1289,22 @@ Optional prefix arg SET-TYPE to choose the cite type."
   "Add the citation's title, either short or full, as an org-mode
 link description to the citation link at point."
   (interactive)
-  (save-excursion
-    (org-ref-open-citation-at-point)
-    (setq title
-          (completing-read "Choose a title: "
-                           (seq-remove
-                            'string-empty-p
-                            `(,(bibtex-autokey-get-field
-                                "shorttitle"
-                                bibtex-autokey-titleword-change-strings)
-                              ,(bibtex-autokey-get-field
-                                "title"
-                                bibtex-autokey-titleword-change-strings)))))
-    (kill-this-buffer))
-  (search-forward-regexp "\\( \\|[^a-zA-Z0-9;:&]\\)")
-  (insert (format "[%s]" title))
-  (forward-char))
+  (let ((title 
+         (progn
+           (org-ref-open-citation-at-point)
+           (completing-read "Choose a title: "
+                            (seq-remove
+                             'string-empty-p
+                             `(,(bibtex-autokey-get-field
+                                 "shorttitle"
+                                 bibtex-autokey-titleword-change-strings)
+                               ,(bibtex-autokey-get-field
+                                 "title"
+                                 bibtex-autokey-titleword-change-strings)))))))
+    (kill-this-buffer)
+    (search-forward-regexp "\\( \\|[^a-zA-Z0-9;:&]\\)")
+    (insert (format "[%s]" title))
+    (forward-char)))
 
 ;; * natmove like pre-processing
 ;;

--- a/org-ref-citation-links.el
+++ b/org-ref-citation-links.el
@@ -1302,7 +1302,7 @@ link description to the citation link at point."
                                  "title"
                                  bibtex-autokey-titleword-change-strings)))))))
     (kill-this-buffer)
-    (search-forward-regexp "\\( \\|[^a-zA-Z0-9;:&]\\)")
+    (goto-char (1- (org-element-property :end (org-element-context))))
     (insert (format "[%s]" title))
     (forward-char)))
 

--- a/org-ref-citation-links.el
+++ b/org-ref-citation-links.el
@@ -558,6 +558,7 @@ PATH has the citations in it."
   ("d" org-ref-delete-citation-at-point "Delete at point" :column "Edit")
   ("r" org-ref-replace-citation-at-point "Replace cite" :column "Edit")
   ("P" org-ref-edit-pre-post-notes "Edit pre/suffix" :column "Edit")
+  ("T" org-ref-cite-add-title-desc "Edit link's title" :column "Edit")
 
   ;; Navigation
   ("[" org-ref-previous-key "Previous key" :column "Navigation" :color red)
@@ -1282,6 +1283,28 @@ Optional prefix arg SET-TYPE to choose the cite type."
   (interactive "P")
   (org-ref-insert-cite-key (org-ref-read-key) set-type))
 
+
+;;;###autoload
+(defun org-ref-cite-add-title-desc ()
+  "Add the citation's title, either short or full, as an org-mode
+link description to the citation link at point."
+  (interactive)
+  (save-excursion
+    (org-ref-open-citation-at-point)
+    (setq title
+          (completing-read "Choose a title: "
+                           (seq-remove
+                            'string-empty-p
+                            `(,(bibtex-autokey-get-field
+                                "shorttitle"
+                                bibtex-autokey-titleword-change-strings)
+                              ,(bibtex-autokey-get-field
+                                "title"
+                                bibtex-autokey-titleword-change-strings)))))
+    (kill-this-buffer))
+  (search-forward-regexp "\\( \\|[^a-zA-Z0-9;:&]\\)")
+  (insert (format "[%s]" title))
+  (forward-char))
 
 ;; * natmove like pre-processing
 ;;


### PR DESCRIPTION
Function `org-ref-cite-add-title-desc` to use the citation's title, either regular or short title, as the org-link description for citation at point. Added a shortcut to the hydra as well.

Useful when working in org-mode: easier to look at the articles' titles than the citation keys.

Example
```
See cite:&devlinBERTPretrainingDeep2019a for more details.
```

turns into:
```
See BERT for more details.
```

Of course, it has no impact on exporting. 