### PR TITLE
doi-utils.el: Accept :type "article" for journal articles

### DIFF
--- a/doi-utils.el
+++ b/doi-utils.el
@@ -967,7 +967,7 @@ MATCHING-TYPES."
                           "}\n")))))))
          doi-utils-bibtex-type-generators))
 
-(doi-utils-def-bibtex-type article ("journal-article" "article-journal")
+(doi-utils-def-bibtex-type article ("journal-article" "article-journal" "article")
                            author title journal year volume number pages doi url)
 
 (doi-utils-def-bibtex-type inproceedings ("proceedings-article" "paper-conference")


### PR DESCRIPTION
* doi-utils.el (article): Recognize JSON :type "article" as a valid
article record.

Example paper with this JSON return value is in
https://arxiv.org/abs/2206.01669.