### PR TITLE
Handle latex mode issues with missing keys.

### DIFF
--- a/org-ref-latex.el
+++ b/org-ref-latex.el
@@ -68,6 +68,7 @@ The clickable part are the keys.")
     (goto-char (match-beginning 0))
     (let ((end (match-end 0)))
       (cl-loop for key in (mapcar #'s-trim (split-string (match-string-no-properties 4) ","))
+	       unless (string-empty-p key)
 	       do
 	       (save-match-data
 		 (search-forward key)

--- a/org-ref-latex.el
+++ b/org-ref-latex.el
@@ -67,7 +67,7 @@ The clickable part are the keys.")
     (setq font-lock-extra-managed-props (delq 'help-echo font-lock-extra-managed-props))
     (goto-char (match-beginning 0))
     (let ((end (match-end 0)))
-      (cl-loop for key in (split-string (match-string-no-properties 4) ",")
+      (cl-loop for key in (mapcar #'s-trim (split-string (match-string-no-properties 4) ","))
 	       do
 	       (save-match-data
 		 (search-forward key)
@@ -84,7 +84,9 @@ The clickable part are the keys.")
 						   (bibtex-beginning-of-entry))))
 					    map)
 			       help-echo ,(let* ((bibtex-completion-bibliography (org-ref-latex-get-bibliography)))
-					    (bibtex-completion-apa-format-reference key))))))
+					    (condition-case nil
+						(bibtex-completion-apa-format-reference key)
+					      (error (display-warning :warning (format "Key %s missing." key)))))))))
       (goto-char end))))
 
 


### PR DESCRIPTION
This PR fixes two issues:
- The key passed to the `bibtex-completion` functions don't remove spaces.
- When a missing key is encountered, `bibtex-completion-apa-format-reference` errors, stopping fontifying the whole buffer.