### PR TITLE
Adding css styles to html csl-backend

### DIFF
--- a/org-ref-export.el
+++ b/org-ref-export.el
@@ -389,7 +389,7 @@ BACKEND is the org export backend."
       ;;
       ;; Here we add style css for html output.
       (cond
-       ((eq 'html backend)
+       ((or (eq 'html backend) (eq 'html csl-backend))
 	(let ((s1 "")
 	      (s2 ""))
 	  (when (cdr (assq 'second-field-align bib-parameters))


### PR DESCRIPTION
Useful when we want a markdown output enriched with html (clickable links, css style, etc.)  
Need to set `(md . html)` in `org-ref-backend-csl-formats` in order to see the result. 