### PR TITLE
Added support to copy/move PDF from citation reference.

### DIFF
--- a/org-ref-citation-links.el
+++ b/org-ref-citation-links.el
@@ -543,6 +543,7 @@ PATH has the citations in it."
 	   (bibtex-copy-entry-as-kill)
 	   (kill-new (pop bibtex-entry-kill-ring))))
    "Copy bibtex" :column "Copy")
+  ("a" org-ref-add-pdf-at-point "add pdf to library" :column "Copy")
   ("k" (kill-new (car (org-ref-get-bibtex-key-and-file))) "Copy key" :column "Copy")
   ("f" (kill-new (bibtex-completion-apa-format-reference
 		  (org-ref-get-bibtex-key-under-cursor)))

--- a/org-ref-pdf.el
+++ b/org-ref-pdf.el
@@ -140,15 +140,7 @@ should be open in Emacs using the `pdf-tools' package."
     (let ((key (org-ref-bibtex-key-from-doi doi)))
       (funcall org-ref-pdf-to-bibtex-function
 	       (buffer-file-name)
-               (expand-file-name (format "%s.pdf" key)
-				 (cond
-				  ((stringp bibtex-completion-library-path)
-				   bibtex-completion-library-path)
-				  ((and (listp bibtex-completion-library-path)
-					(= 1 (length bibtex-completion-library-path)))
-				   (car bibtex-completion-library-path))
-				  (t
-				   (completing-read "Dir: " bibtex-completion-library-path))))))))
+               (expand-file-name (format "%s.pdf" key) (org-ref-library-path))))))
 
 
 ;;;###autoload


### PR DESCRIPTION
This patch improves the functionality when typing return on a reference.

It adds the option to copy/add the PDF to the current citation.  If the citation already has a PDF, a message is issued and nothing happens.

This commit adds two functions:

  org-ref-library-path
     "return the library path".
     This function has been refactored from org-ref-pdf-to-bibtex

   org-ref-add-pdf-at-point
      "Add the pdf for bibtex key under point if it exists."

And add the new functionality to org-ref-citation-hydra and modifies org-ref-pdf-to-bibtex to use the refactored org-ref-library-path.