### PR TITLE
fix: use uppercase Crefrange

### DIFF
--- a/org-ref-ref-links.el
+++ b/org-ref-ref-links.el
@@ -469,7 +469,7 @@ This is meant to be used with `apply-partially' in the link definitions."
   (pcase backend
     ('latex
      (let ((labels (split-string path ",")))
-       (format "\\crefrange{%s}{%s}" (cl-first labels) (cl-second labels))))))
+       (format "\\Crefrange{%s}{%s}" (cl-first labels) (cl-second labels))))))
 
 
 (defun org-ref-crefrange-complete (cmd &optional _arg)


### PR DESCRIPTION
Tiny change to use \Crefrange rather than \crefrange when Crefrange is used in org-mode (currently \crefrange is always used)

Many thanks for this package!