### PR TITLE
Fix compilation error for org-ref-refproc under Nix

### DIFF
--- a/org-ref-ref-links.el
+++ b/org-ref-ref-links.el
@@ -23,6 +23,7 @@
 
 ;;; Code:
 (eval-and-compile (require 'org-macs))
+(eval-and-compile (require 'ol))
 (require 'hydra)
 
 (defcustom org-ref-default-ref-type "ref"


### PR DESCRIPTION
Fixes 

```
Warning (comp): org-ref-refproc.el: Error: Symbol's function definition is void org-link-set-parameters
```

When using native compilation and the Nix package manager, each elisp package is native compiled in a separate sandbox.

`org-ref-refproc.el` requires`org-ref-ref-links`, which in turn was calling `org-link-set-parameters`, but `ol` from `org-mode` had not been required. I am guessing that this is only a problem when the package is being compiled in a sandbox, since `ol` will almost certainly be loaded in any reasonable init file using org-ref.