### PR TITLE
Fix for inactive doi in arxiv data

### DIFF
--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -137,9 +137,9 @@ Returns a formatted BibTeX entry."
 		  (org-ref-replace-nonascii)
                   (bibtex-generate-autokey)))
 	   (doi (assq 'doi entry)))
-      (if doi
-	  (doi-utils-doi-to-bibtex-string (nth 2 doi))
-	;; no doi, so we fall back to the simple template
+      (unless (and doi
+	           (ignore-errors (doi-utils-doi-to-bibtex-string (nth 2 doi))))
+	;; no doi or inactive doi, so we fall back to the simple template
 	(format arxiv-entry-format-string key title names year arxiv-number category abstract url)))))
 
 


### PR DESCRIPTION
Fix for #1108 

When trying to add an arxiv entry that has a doi, if the doi is inactive, it causes the `arxiv-get-bibtex-entry-via-arxiv-api` to fail. If an arxiv entry has a doi, this fix first tries to add it. If that fails, it falls back to the simple template.